### PR TITLE
fix(slidev): fix 6 issues discovered during real-world CJK deck creation

### DIFF
--- a/skills/slidev/ISSUES.md
+++ b/skills/slidev/ISSUES.md
@@ -1,0 +1,91 @@
+# Slidev Skill — Known Issues
+
+> Discovered during real-world usage (GM report deck, 50 slides, CJK-heavy, text-heavy verbosity, converting from existing Obsidian document with images).
+
+---
+
+## Issue 1: char_count includes markdown formatting in length
+
+**Status**: Fixed
+**Severity**: Medium
+**File**: `scripts/validate-slides.sh` lines 284-291
+
+**Problem**: The `char_count()` function strips HTML tags via `re.sub(r"<[^>]+>", "")` but does **not** strip markdown formatting (`**bold**`, `*italic*`, `` `code` ``). A 40-character Chinese sentence wrapped in `**...**` counts as 44 characters. In CJK-heavy text-heavy decks, this produces false WARN results that cannot be resolved by shortening content.
+
+**Expected**: `char_count` should measure *visible text length*, stripping both HTML tags and markdown inline formatting.
+
+**Fix applied**: Added `strip_md()` helper that removes `**`, `*`, and backtick wrappers before counting. `char_count()` now calls `strip_md()` first. SP1 static test suite passes (10/10).
+
+---
+
+## Issue 2: No "document-to-slides" conversion workflow
+
+**Status**: Fixed
+**Severity**: High
+**File**: `SKILL.md` Step 1
+
+**Problem**: The workflow assumes creating presentations from scratch. The most common real-world scenario is converting an existing structured document (Obsidian note, Google Doc, markdown file) into slides. Missing:
+- Asset inventory step (which images/videos exist, where are they stored)
+- Media migration instructions (copy to `public/`, path conversion)
+- Obsidian wikilink (`![[...]]`) to slidev path (`/filename.png`) conversion rules
+- Guidance on handling missing/unreachable assets (placeholders, comments)
+
+**Fix applied**: Added "Converting an Existing Document" subsection to Step 1 in SKILL.md, covering: asset inventory, media migration to `public/`, path conversion rules (wikilink → `<img>`), content mapping (H2 → section-divider + slides).
+
+---
+
+## Issue 3: Image handling ignores existing user assets
+
+**Status**: Fixed
+**Severity**: High
+**File**: `SKILL.md` SP2 section, `references/layout-catalog.md`
+
+**Problem**: SP2 documentation focuses entirely on AI-generated images via Gemini. No guidance exists for the basic case of using existing screenshots, concept art, data charts, or exported diagrams. Specific gaps:
+- `image_path` override is mentioned once in layout-catalog but under-documented
+- No recommended CSS patterns for sizing existing images within slides
+- `image-focus` layout defaults to full-slide coverage, which is wrong for data tables/charts
+- No guidance on when to use `image-focus` vs inline `<img>` with sizing classes
+
+**Fix applied**: Added "Using Existing Images (without SP2)" section to SKILL.md after SP2, covering: setup (copy to `public/`), frontmatter for existing images (`image_path` + `image_prompt`), inline `<img>` sizing approach, image sizing tiers table (Small/Medium/Large/Full), and decision guide for which approach to use.
+
+---
+
+## Issue 4: two-columns frontmatter requirement not visible
+
+**Status**: Fixed
+**Severity**: Medium
+**File**: `SKILL.md` Critical Gotchas, `references/layout-catalog.md`
+
+**Problem**: The `two-columns` layout requires `left:` and `right:` objects with `pattern:` fields in the slide frontmatter for validation to pass. This requirement is buried in layout-catalog.md prose and a single sentence in SKILL.md Step 3 (line ~291). First-time users will write two-columns slides without the frontmatter objects, get FAIL from validate-slides.sh, and have no clear error message pointing to the fix.
+
+**Fix applied**:
+- Added Critical Gotcha #6 in SKILL.md with complete YAML frontmatter example showing `left:` and `right:` objects with `pattern:` fields
+- Added CRITICAL callout + complete frontmatter YAML example (bullets × table) in layout-catalog.md's two-columns section, before the existing markdown template
+
+---
+
+## Issue 5: No medium-size image layout or guidance
+
+**Status**: Fixed
+**Severity**: Medium
+**File**: `references/content-design.md`
+
+**Problem**: Only two image size extremes exist:
+- `image-focus`: full-slide image (too large for data charts, cost tables, concept sketches)
+- `two-columns` image pattern: `max-h-64` (256px, too small for detailed images)
+
+No layout or guidance for the most common case: a **medium-sized image** (~288-384px) with a title above and optional caption below. Users must guess CSS classes.
+
+**Fix applied**: Added "Image Sizing Guide" section to content-design.md with: 4-tier sizing table (Small `max-h-48` / Medium `max-h-72` / Large `max-h-96` / Full `image-focus`), HTML code examples, and a decision tree for choosing the right tier.
+
+---
+
+## Issue 6: Verbosity has no scenario mapping
+
+**Status**: Fixed
+**Severity**: Low
+**File**: `references/content-strategy.md` §6
+
+**Problem**: The three verbosity levels (concise / standard / text-heavy) are defined with fill-ratio targets but no guidance on when to pick each. Users default to `standard` even when their content (e.g., GM report with detailed reasoning, lecture handout) clearly needs `text-heavy`. No mapping to audience types, purposes, or common presentation scenarios.
+
+**Fix applied**: Added "Choosing verbosity" table to content-strategy.md §6 with 8 common scenarios mapped to recommended verbosity + rationale, plus a rule of thumb ("if the audience will read slides later without the speaker → text-heavy").

--- a/skills/slidev/SKILL.md
+++ b/skills/slidev/SKILL.md
@@ -170,6 +170,38 @@ Combined with CSS utilities (`text-sm`, `compact-table`, `max-h-*`,
 - If text drops below ~11px effective size, split instead — unreadable text is
   worse than an extra slide
 
+**6. `two-columns` requires `left:` and `right:` objects in frontmatter**
+
+The `two-columns` layout uses Slidev's `two-cols-header` built-in. For
+`validate-slides.sh` Check 10 to pass, **both `left` and `right` must be
+declared as objects in the slide frontmatter** with at least a `pattern` field.
+Without them, validation will FAIL with "two-columns missing 'left' object".
+
+```yaml
+---
+layout: two-cols-header
+class: two-columns
+left:
+  pattern: bullets
+  items:
+    - First point
+    - Second point
+right:
+  pattern: table
+  columns:
+    - Col A
+    - Col B
+  rows:
+    - - R1A
+      - R1B
+    - - R2A
+      - R2B
+---
+```
+
+The 6 available patterns are: `text`, `bullets`, `code`, `image`, `table`,
+`metric`. See `references/layout-catalog.md` for each pattern's fields.
+
 ---
 
 ## Workflow
@@ -199,6 +231,30 @@ When run, the script copies the starter template, substitutes title/date/author,
 the `public/fonts/` directory, symlinks the shared runner's `node_modules` into
 the target directory (so Slidev can find Mermaid, themes, and other plugins),
 and ensures the runner is ready.
+
+#### Converting an Existing Document
+
+When the user provides an existing document (Obsidian note, markdown file, etc.)
+to convert into slides, perform these additional steps before proceeding to Step 2:
+
+1. **Asset inventory** — scan the source document for image/video references
+   (`![[...]]` wikilinks, `![](...)` markdown images, `<img>` tags). For each:
+   - Locate the file on disk (check `./assets/`, Obsidian attachment folder, etc.)
+   - If found: note the absolute path for later migration to `public/`
+   - If not found: note it as missing — add a placeholder comment in the slide
+     (`<!-- TODO: add <filename> to public/ -->`)
+2. **Media migration** — after initializing the deck (Step 3), copy all found
+   assets into `<target_dir>/public/`. In slides, reference them as `/<filename>`
+   (relative to `public/`).
+3. **Path conversion rules**:
+   - Obsidian wikilink `![[image.png]]` → `<img src="/image.png" ... />`
+   - Markdown `![alt](path/to/img.png)` → copy to `public/`, use `<img src="/img.png" ... />`
+   - Videos (`.mov`, `.mp4`) cannot be embedded in Slidev slides directly;
+     note them as presenter-only references or link externally.
+4. **Content mapping** — each major section (H2) in the source typically maps
+   to a section-divider + 2-6 content slides. Tables map to `data-table`,
+   bullet lists to `content-bullets`, standalone images to inline `<img>` with
+   sizing (see "Using Existing Images" below).
 
 ### Step 2: Content Strategy & Style Decisions
 
@@ -527,3 +583,67 @@ Static test suite: `bash scripts/test-sp2-static.sh`.
 ### Troubleshooting
 
 See `references/image-generation.md` §11.
+
+---
+
+## Using Existing Images (without SP2)
+
+When the source material already contains screenshots, concept art, data charts,
+or exported diagrams, use them directly instead of generating images via SP2.
+
+### Setup
+
+1. Copy image files into `<target_dir>/public/` (any subdirectory is fine,
+   e.g., `public/screenshots/`, `public/charts/`)
+2. Reference them in slides as `/<filename>` or `/<subdir>/<filename>`
+
+### Frontmatter for existing images
+
+When using `image-focus` or `image-text-split` layouts with existing images,
+set `image_path` in the slide frontmatter to suppress SP2 generation:
+
+```yaml
+image_path: public/my-screenshot.png
+image_prompt: "description for accessibility and fallback"
+```
+
+Both fields are still needed for validation. `image_prompt` serves as the
+alt-text source and SP2 fallback if the file is missing.
+
+### Image sizing (inline approach)
+
+For most existing images (data charts, cost tables, concept sketches), avoid
+the `image-focus` layout — it fills the entire slide. Instead, use a standard
+layout with an inline `<img>` and Tailwind sizing classes:
+
+```markdown
+---
+layout: default
+class: skeleton-list content-narrative
+---
+
+# Slide Title
+
+<div class="flex justify-center mt-4">
+  <img src="/chart.png" alt="description" class="max-h-72 object-contain rounded shadow" />
+</div>
+```
+
+### Image sizing tiers
+
+| Tier | CSS class | Height | Use for |
+|------|-----------|--------|---------|
+| Small | `max-h-48` | 192px | Supplementary inline icon/badge |
+| Medium | `max-h-72` | 288px | Data charts, cost tables, concept sketches |
+| Large | `max-h-96` | 384px | Detailed diagrams, wide screenshots |
+| Full | `image-focus` layout | ~500px+ | Hero photos, branding, full-bleed images |
+
+Always pair with `object-contain` to prevent cropping. Add `rounded shadow`
+for a polished look on light backgrounds.
+
+### When to use which approach
+
+- **Data table screenshot** → Medium (`max-h-72`) inline `<img>`, not `image-focus`
+- **UI concept art / mockup** → Large (`max-h-96`) or `image-text-split` layout
+- **Hero photo / branding** → `image-focus` layout (full slide)
+- **Small comparison images** → `two-columns` layout with `image` pattern

--- a/skills/slidev/references/content-design.md
+++ b/skills/slidev/references/content-design.md
@@ -270,6 +270,44 @@ sequenceDiagram
 Key takeaway: the round-trip adds ~40ms latency.
 ```
 
+### Image Sizing Guide
+
+When embedding existing images (screenshots, data charts, concept art), choose
+the right size tier to avoid overflow or wasted space. Slidev's viewport is
+980×552 px — after title and padding, the usable content area is ~450px tall.
+
+| Tier | CSS class | Height | Best for |
+|------|-----------|--------|----------|
+| Small | `max-h-48` | 192px | Supplementary icon, badge, small inline visual |
+| Medium | `max-h-72` | 288px | Data chart, cost table screenshot, concept sketch |
+| Large | `max-h-96` | 384px | Detailed diagram, wide screenshot, UI mockup |
+| Full | `image-focus` layout | ~500px+ | Hero photo, branding, full-bleed visual anchor |
+
+**Always combine with**: `object-contain` (prevent cropping) + `mx-auto` (center).
+Optional: `rounded shadow` for polished look on light backgrounds.
+
+```html
+<!-- Medium: most common for data/chart images -->
+<div class="flex justify-center mt-4">
+  <img src="/chart.png" alt="description"
+       class="max-h-72 object-contain rounded shadow" />
+</div>
+
+<!-- Large: detailed diagrams needing more space -->
+<div class="flex justify-center mt-2">
+  <img src="/architecture.png" alt="description"
+       class="max-h-96 object-contain" />
+</div>
+```
+
+**Decision tree**:
+- Is the image the *only* content on the slide? → `image-focus` layout (Full)
+- Does the image need explanation text beside it? → `image-text-split` layout
+- Is the image a data table/chart with a title above? → Medium (`max-h-72`)
+- Is the image inside a `two-columns` column? → Small (`max-h-48`) or the
+  `image` content pattern (`max-h-64`)
+- Is the image detailed and needs study time? → Large (`max-h-96`)
+
 ## Visual Hierarchy
 
 Guide the eye with size and weight:

--- a/skills/slidev/references/content-strategy.md
+++ b/skills/slidev/references/content-strategy.md
@@ -126,6 +126,23 @@ How densely each slide should be populated:
 
 If unclear, default to `standard`.
 
+**Choosing verbosity** — use this table to pick based on audience and purpose:
+
+| Scenario | Verbosity | Why |
+|----------|-----------|-----|
+| Executive brief, board update, 5-min pitch | `concise` | Time-poor audience; every word must earn its place |
+| Conference keynote, inspirational talk | `concise` | Impact > information density; audience follows the speaker |
+| Standard internal presentation, sprint review | `standard` | Balanced — enough detail to follow, not so much it overwhelms |
+| Workshop with hands-on exercises | `standard` | Slides guide but don't replace the activity |
+| GM/VP report with data + reasoning + asks | `text-heavy` | Decision-makers need the argument chain visible on the slide |
+| Lecture slides that double as handout | `text-heavy` | Students will re-read independently; slides must stand alone |
+| Technical deep-dive, architecture review | `text-heavy` | Peers expect detailed evidence, not just headlines |
+| Playbook, onboarding guide, SOP | `text-heavy` | Reference material; completeness > brevity |
+
+**Rule of thumb**: if the audience will *read the slides later without the speaker*,
+use `text-heavy`. If the speaker *is* the content and slides are visual support,
+use `concise`. Everything else is `standard`.
+
 **Coupling with `maxLength`**: verbosity controls how much of each field Claude
 fills (target fill-ratio: concise 30-50%, standard 50-75%, text-heavy 75-100%).
 `maxLength` itself is a hard ceiling and does NOT scale with verbosity —

--- a/skills/slidev/references/layout-catalog.md
+++ b/skills/slidev/references/layout-catalog.md
@@ -833,6 +833,34 @@ layout: two-cols-header
 class: two-columns
 ```
 
+> **CRITICAL**: `validate-slides.sh` requires both `left` and `right` objects
+> in the frontmatter with at least a `pattern` field. Without them, Check 10
+> will FAIL. See complete example below.
+
+**Complete frontmatter example** (bullets × table):
+```yaml
+---
+layout: two-cols-header
+class: two-columns
+left:
+  pattern: bullets
+  items:
+    - First claim
+    - Second claim
+    - Third claim
+right:
+  pattern: table
+  columns:
+    - Metric
+    - Value
+  rows:
+    - - DAU
+      - 39.6 万
+    - - MAU
+      - 125 万
+---
+```
+
 > Uses Slidev's `two-cols-header` built-in (NOT plain `two-cols`). `two-cols-header` has three slots — `default` (top header, holds the `# title`), `::left::`, and `::right::`. Plain `two-cols` only has `::left::` / `::right::` and would push the `# title` into the left column, which is wrong for heterogeneous comparisons.
 
 **When to use**:

--- a/skills/slidev/scripts/validate-slides.sh
+++ b/skills/slidev/scripts/validate-slides.sh
@@ -281,8 +281,15 @@ while k < len(rest):
     slides.append((fm, body_chunk))
     k += 2
 
+def strip_md(s):
+    """Strip markdown inline formatting to measure visible text length."""
+    s = re.sub(r'\*\*(.+?)\*\*', r'\1', s)   # bold
+    s = re.sub(r'\*(.+?)\*', r'\1', s)         # italic
+    s = re.sub(r'`(.+?)`', r'\1', s)           # inline code
+    return s
+
 def char_count(s):
-    return len(s)
+    return len(strip_md(s))
 
 fails = []
 warns = []


### PR DESCRIPTION
## Summary

Fix 6 issues discovered while using the slidev skill to convert a real GM report (50 slides, CJK-heavy, text-heavy verbosity) from an existing Obsidian document.

## Issues Fixed

| # | Issue | Severity | Files Changed |
|---|-------|----------|---------------|
| 1 | `char_count` includes markdown formatting (`**`, `*`, backticks) in length measurement | Medium | `scripts/validate-slides.sh` |
| 2 | No document-to-slides conversion workflow | High | `SKILL.md` |
| 3 | Image handling ignores existing user assets (only covers AI generation) | High | `SKILL.md` |
| 4 | `two-columns` frontmatter requirement buried / not visible | Medium | `SKILL.md`, `references/layout-catalog.md` |
| 5 | No medium-size image layout or sizing guidance | Medium | `references/content-design.md` |
| 6 | Verbosity has no scenario mapping (when to pick concise/standard/text-heavy) | Low | `references/content-strategy.md` |

## Key Changes

- **validate-slides.sh**: Added `strip_md()` helper to remove markdown formatting before character counting, eliminating false WARNs on CJK text with bold/italic
- **SKILL.md**: Added "Converting an Existing Document" subsection (asset inventory, media migration, path conversion); Added "Using Existing Images" section with sizing tiers; Added Critical Gotcha #6 for two-columns frontmatter
- **content-design.md**: Added Image Sizing Guide (Small/Medium/Large/Full tiers with CSS classes and decision tree)
- **content-strategy.md**: Added "Choosing verbosity" table with 8 scenario mappings
- **layout-catalog.md**: Added CRITICAL callout and complete YAML frontmatter example for two-columns
- **ISSUES.md**: Created issue tracker documenting all 6 issues (all marked Fixed)

## Testing

- SP1 static test suite: 10/10 pass
- Validated against the real 50-slide GM report deck: 12/12 PASS, 0 FAIL, 0 WARN