### PR TITLE
feat: add expert red-team review skill

### DIFF
--- a/skills/expert-redteam-review/SKILL.md
+++ b/skills/expert-redteam-review/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: expert-redteam-review
+description: Use when a user asks to evaluate a complex, high-impact, ambiguous, cross-functional, or hard-to-reverse decision; mentions expert panel, red team, adversarial review, rebuttal, judge, arbitration, risk review, challenge assumptions, poke holes, or wants stronger decision quality than a normal review.
+version: "1.0.0"
+author: carbonshow
+tags: [decision-quality, expert-review, red-team, orchestration, risk]
+---
+
+# Expert Red-Team Review
+
+Use this skill to improve decision quality for complex work. The main agent stays accountable for state, scope, synthesis, and final communication. Experts, red team, rebuttal, and judge roles exist to reveal blind spots; they do not replace the user's decision.
+
+## Core Rules
+
+- Scale the workflow to the task. Do not run a full panel for trivial work.
+- Keep expert initial judgments independent. Do not show one expert another expert's initial answer.
+- Prefer 3-5 experts for serious reviews. More than 5 usually adds integration noise.
+- Build vertical-domain experts from success criteria and failure modes; do not pretend a generic role is domain expertise.
+- Label important claims with evidence tags: `[source]`, `[code]`, `[test]`, `[data]`, `[inference]`, `[engineering-judgment]`, `[creative-judgment]`, or `[unknown]`.
+- Optimize for decision quality, not consensus. Preserve meaningful disagreement.
+- The judge must arbitrate. A judge that only summarizes has failed.
+- P0/P1 red-team findings require minimum fixes. P2 risks require explicit acceptance rationale.
+- For one-way-door or high-blast-radius actions, stop at recommendation and ask for human approval before execution.
+
+## Level Selection
+
+| Level | Use When | Shape |
+|---|---|---|
+| L0 Quick Check | The user wants a fast challenge or self-check. | Single-agent red-team review. |
+| L1 Expert Review | 2-3 perspectives are useful, but formal adversarial review is unnecessary. | Small independent expert panel, no red team. |
+| L2 Full Review | The user asks for expert panel/red team/judge or the decision has major uncertainty. | Expert panel, synthesis, red team, rebuttal, judge. |
+| L3 Gated Review | The decision is hard to reverse or affects production, security, privacy, finance, compliance, or shared systems. | L2 plus explicit human gate before action. |
+
+Default downshift: if the task is low-risk or the user asks for speed, choose the lowest useful level. Default upshift: if L0/L1 reveals P0/P1 risks or severe disagreement, propose L2.
+
+## Operating Flow
+
+1. Triage the request and choose L0-L3.
+2. Build a compact context package: decision point, scope, non-goals, hard constraints, success criteria, evidence policy, and output target.
+3. Select orthogonal roles. For vertical domains, construct role cards from domain success criteria and failure modes.
+4. Run independent expert analysis when L1+ is needed.
+5. Synthesize consensus and disagreements. Lead with disagreements that affect the decision.
+6. Run red-team attack for L2/L3.
+7. Run rebuttal from relevant experts only.
+8. Judge the result: supported claims, weak claims, blocking risks, accepted risks, rejected alternatives, recommended path, minimum validation.
+9. For L3, ask the user before executing any irreversible or externally visible action.
+
+## Reference Files
+
+| File | Read When |
+|---|---|
+| `references/workflow.md` | You need the detailed L0-L3 workflow, escalation rules, or failure handling. |
+| `references/role-library.md` | You need to choose experts or construct vertical-domain roles. |
+| `references/templates.md` | You need prompt/output templates for context package, experts, red team, rebuttal, or judge. |
+| `references/surge-integration.md` | The task involves an optional integration with surge. |
+| `references/evaluation.md` | You need to check whether the review itself is high quality. |
+
+## Output Contract
+
+For L0, keep the answer compact. For L1-L3, produce a decision package with:
+
+- Final judgment.
+- Recommended path and rejected alternatives.
+- Must-fix issues.
+- Accepted residual risks.
+- Open or deferred questions.
+- Minimum validation action.
+- Human gate status.
+- Files created or changed, if any.
+
+## Common Failure Modes
+
+- A panel gives agreeable summaries but no decision.
+- The red team attacks style instead of core assumptions.
+- The judge averages opinions instead of arbitrating.
+- Generic roles are used for a vertical domain without constructing domain-specific lenses.
+- The workflow becomes a hard dependency for another system that should only use it as an optional checkpoint.
+- The output is long but not actionable.

--- a/skills/expert-redteam-review/SKILL.md
+++ b/skills/expert-redteam-review/SKILL.md
@@ -16,6 +16,7 @@ Use this skill to improve decision quality for complex work. The main agent stay
 - Keep expert initial judgments independent. Do not show one expert another expert's initial answer.
 - Prefer 3-5 experts for serious reviews. More than 5 usually adds integration noise.
 - Build vertical-domain experts from success criteria and failure modes; do not pretend a generic role is domain expertise.
+- For vertical-domain L2/L3 work, propose the domain-specific panel and ask the user to confirm or adjust it before running the full review, unless the user has already approved the panel.
 - Label important claims with evidence tags: `[source]`, `[code]`, `[test]`, `[data]`, `[inference]`, `[engineering-judgment]`, `[creative-judgment]`, or `[unknown]`.
 - Optimize for decision quality, not consensus. Preserve meaningful disagreement.
 - The judge must arbitrate. A judge that only summarizes has failed.
@@ -38,12 +39,13 @@ Default downshift: if the task is low-risk or the user asks for speed, choose th
 1. Triage the request and choose L0-L3.
 2. Build a compact context package: decision point, scope, non-goals, hard constraints, success criteria, evidence policy, and output target.
 3. Select orthogonal roles. For vertical domains, construct role cards from domain success criteria and failure modes.
-4. Run independent expert analysis when L1+ is needed.
-5. Synthesize consensus and disagreements. Lead with disagreements that affect the decision.
-6. Run red-team attack for L2/L3.
-7. Run rebuttal from relevant experts only.
-8. Judge the result: supported claims, weak claims, blocking risks, accepted risks, rejected alternatives, recommended path, minimum validation.
-9. For L3, ask the user before executing any irreversible or externally visible action.
+4. If the task is vertical-domain L2/L3 and the panel has not already been confirmed, stop and ask the user to confirm or adjust the proposed panel before full review.
+5. Run independent expert analysis when L1+ is needed.
+6. Synthesize consensus and disagreements. Lead with disagreements that affect the decision.
+7. Run red-team attack for L2/L3.
+8. Run rebuttal from relevant experts only.
+9. Judge the result: supported claims, weak claims, blocking risks, accepted risks, rejected alternatives, recommended path, minimum validation.
+10. For L3, ask the user before executing any irreversible or externally visible action.
 
 ## Reference Files
 

--- a/skills/expert-redteam-review/evals/evals.json
+++ b/skills/expert-redteam-review/evals/evals.json
@@ -1,0 +1,23 @@
+{
+  "skill_name": "expert-redteam-review",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Review this high-risk architecture migration plan with an expert panel and red-team challenge: migrate a monolith payment service to event-driven microservices next quarter. Give me a decision package with a judge ruling.",
+      "expected_output": "Selects L2 or L3, uses independent expert lenses, identifies payment-specific failure modes, classifies red-team findings, gives a clear recommendation, and requires a human gate if execution is proposed.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "prompt": "Help me assemble an expert panel and red team to evaluate a xianxia web novel series outline with cultivation system, long-serialization pacing, reader retention, and cliche risks.",
+      "expected_output": "Constructs vertical-domain expert role cards from genre success criteria and failure modes rather than relying only on generic roles.",
+      "files": []
+    },
+    {
+      "id": 3,
+      "prompt": "I run an orchestration workflow called surge. Should expert-redteam-review become a hard dependency, and how should it integrate with design/QA phases?",
+      "expected_output": "Keeps expert-redteam-review independent, makes surge integration optional, avoids hard dependency, defines minimum input/output packages and veto/severity mapping.",
+      "files": []
+    }
+  ]
+}

--- a/skills/expert-redteam-review/evals/evals.json
+++ b/skills/expert-redteam-review/evals/evals.json
@@ -5,19 +5,40 @@
       "id": 1,
       "prompt": "Review this high-risk architecture migration plan with an expert panel and red-team challenge: migrate a monolith payment service to event-driven microservices next quarter. Give me a decision package with a judge ruling.",
       "expected_output": "Selects L2 or L3, uses independent expert lenses, identifies payment-specific failure modes, classifies red-team findings, gives a clear recommendation, and requires a human gate if execution is proposed.",
-      "files": []
+      "files": [],
+      "assertions": [
+        "Selects an L2 or L3 review level or otherwise explicitly treats the task as high-risk/gated.",
+        "Uses multiple distinct expert lenses relevant to payment migration.",
+        "Includes red-team findings with severity or blocker/must-fix distinction.",
+        "Provides a judge ruling or clear arbitration, not only a summary.",
+        "Includes minimum validation actions and a human gate or approval requirement before execution."
+      ]
     },
     {
       "id": 2,
       "prompt": "Help me assemble an expert panel and red team to evaluate a xianxia web novel series outline with cultivation system, long-serialization pacing, reader retention, and cliche risks.",
       "expected_output": "Constructs vertical-domain expert role cards from genre success criteria and failure modes rather than relying only on generic roles.",
-      "files": []
+      "files": [],
+      "assertions": [
+        "Constructs domain-specific expert roles rather than only generic product/architecture roles.",
+        "Each proposed role includes a clear review lens or failure modes to catch.",
+        "Covers cultivation-system coherence, long-serialization pacing, reader retention, and cliche/fatigue risk.",
+        "Includes or proposes a red-team/adversarial role focused on genre failure modes.",
+        "For vertical-domain requests, proposes the domain-specific panel and asks the user to confirm or adjust it before running a full L2/L3 review."
+      ]
     },
     {
       "id": 3,
       "prompt": "I run an orchestration workflow called surge. Should expert-redteam-review become a hard dependency, and how should it integrate with design/QA phases?",
       "expected_output": "Keeps expert-redteam-review independent, makes surge integration optional, avoids hard dependency, defines minimum input/output packages and veto/severity mapping.",
-      "files": []
+      "files": [],
+      "assertions": [
+        "States that expert-redteam-review should not become a hard dependency of surge.",
+        "Frames integration as optional and non-blocking when the skill is unavailable.",
+        "Defines concrete use criteria for invoking it during design or QA.",
+        "Provides a minimal input/output package or equivalent integration contract.",
+        "Maps severe findings or vetoes into surge design/QA handling without changing surge core state/scripts."
+      ]
     }
   ]
 }

--- a/skills/expert-redteam-review/references/evaluation.md
+++ b/skills/expert-redteam-review/references/evaluation.md
@@ -1,0 +1,111 @@
+# Evaluation Criteria
+
+Use this reference to check whether an expert red-team review actually improved decision quality.
+
+## Decision Quality
+
+A good review:
+- Gives a clear final judgment, not a vague summary.
+- Names the recommended path and rejected alternatives.
+- Preserves disagreements that affect the decision.
+- Distinguishes one-way-door and two-way-door decisions.
+- Identifies when more evidence is needed before action.
+
+Failure signs:
+- Everyone appears to agree without meaningful reasoning.
+- The answer is balanced but does not decide.
+- The recommendation ignores reversibility or blast radius.
+
+## Evidence Quality
+
+A good review:
+- Labels important claims with evidence tags.
+- Separates facts, inference, expert judgment, creative judgment, and unknowns.
+- Uses domain-appropriate evidence standards.
+- Does not treat model confidence as evidence.
+
+Failure signs:
+- Strong claims have no source, code, test, data, or reasoning trail.
+- Domain claims are generic and could apply anywhere.
+- Unknowns are hidden behind confident language.
+
+## Role Quality
+
+A good review:
+- Selects roles based on failure modes.
+- Uses orthogonal lenses.
+- Constructs vertical-domain roles when the task demands it.
+- Asks the user to confirm roles when domain criteria are unclear.
+
+Failure signs:
+- The same role appears under multiple names.
+- A generic expert panel pretends to be specialized.
+- More experts are added without improving coverage.
+
+## Red-Team Quality
+
+A good red team:
+- Attacks core assumptions, not formatting.
+- Finds counterexamples and edge conditions.
+- Checks incentives, metrics, cost, operations, security, privacy, compliance, and domain-specific failure modes.
+- Classifies findings as P0/P1/P2/P3.
+- Provides minimum fixes for P0/P1.
+
+Failure signs:
+- Red-team findings are polite suggestions only.
+- P0/P1 findings do not include minimum fixes.
+- Everything is labeled severe, causing unnecessary paralysis.
+
+## Rebuttal Quality
+
+A good rebuttal:
+- Responds only to relevant findings.
+- Marks each finding as accepted, mitigated, disputed, or deferred.
+- Explains what changes if the finding is accepted.
+- Does not dismiss red-team issues without evidence.
+
+Failure signs:
+- Experts defend the original proposal reflexively.
+- Rebuttal becomes a second generic review.
+- Disputed findings have no evidence basis.
+
+## Judge Quality
+
+A good judge:
+- Arbitrates rather than summarizes.
+- States supported claims, weak claims, blocking risks, and accepted risks.
+- Chooses a recommended path.
+- Names minimum validation action.
+- Requires a human gate for high-blast-radius actions.
+
+Failure signs:
+- The judge averages expert opinions.
+- The judge avoids choosing between alternatives.
+- The judge ignores P0/P1 findings.
+
+## Output Usability
+
+A useful final answer:
+- Is short enough to act on and long enough to justify the decision.
+- Provides next actions, not just analysis.
+- Includes files changed or created when applicable.
+- Makes human approval requirements explicit.
+
+Failure signs:
+- Long report, no next step.
+- Lists risks without prioritizing them.
+- Leaves the user unable to decide.
+
+## Self-Check Before Final Answer
+
+Before presenting the final package, check:
+
+- Did I choose the smallest adequate level?
+- Did I construct domain experts when needed?
+- Did experts start independently?
+- Did the red team attack the core decision?
+- Did every P0/P1 get a minimum fix?
+- Did the judge make a decision?
+- Did I distinguish supported claims from unknowns?
+- Did I identify the minimum validation action?
+- Did I ask for human approval before any L3 execution?

--- a/skills/expert-redteam-review/references/role-library.md
+++ b/skills/expert-redteam-review/references/role-library.md
@@ -1,0 +1,133 @@
+# Role Library and Domain Expert Construction
+
+The role library is not a fixed cast. It is a set of review lenses plus a protocol for constructing vertical-domain experts.
+
+## Selection Principles
+
+1. **Prefer orthogonality**: avoid multiple roles that repeat the same concern.
+2. **Choose by failure mode**: roles exist to catch ways the decision can fail.
+3. **Cap serious reviews at 3-5 experts**: more usually adds synthesis noise.
+4. **Include an execution lens**: complex decisions need someone to inspect delivery, testing, operations, or maintenance.
+5. **Construct domain experts when needed**: do not force a generic role onto a specialized field.
+6. **Ask before pretending**: if domain success criteria are unclear, ask the user to confirm the panel.
+
+## Universal Review Lenses
+
+| Lens | Use For | Catches |
+|---|---|---|
+| Product / Domain Reviewer | Product, strategy, user value, requirements. | False user assumptions, weak value proposition, scope drift. |
+| System Architect | Architecture, boundaries, interfaces, complexity. | Tight coupling, unclear contracts, over-engineering, migration traps. |
+| Delivery / Project Reviewer | Plans, dependencies, rollout, resources. | Unrealistic timelines, hidden dependencies, sequencing risk. |
+| Quality / Test Reviewer | Acceptance criteria, test strategy, regressions. | Untestable claims, weak coverage, missing edge cases. |
+| Security / Privacy Reviewer | Data, access, abuse, compliance. | Permission gaps, privacy leaks, misuse, regulatory exposure. |
+| UX / Cognitive Load Reviewer | Workflows, UI, user understanding. | Confusing flows, adoption friction, poor error recovery. |
+| Economics / Maintenance Reviewer | ROI, opportunity cost, ongoing cost. | Expensive low-value work, maintenance burden, hidden recurring cost. |
+| Operations / SRE Reviewer | Production, monitoring, incidents, rollback. | Poor observability, fragile rollout, recovery gaps. |
+| Research / Evidence Reviewer | Research, citations, external claims. | Weak evidence, overgeneralization, stale sources. |
+
+## Technical Signal Mapping
+
+| Signal | Candidate Roles |
+|---|---|
+| API, backend, database | Backend Architect, Database Reviewer, Security Reviewer |
+| Frontend, component, interaction | Frontend Architect, UX Reviewer, Accessibility Reviewer |
+| AI, agents, LLMs, prompts | Agent Systems Reviewer, Evaluation Reviewer, Safety Reviewer |
+| Performance, scale, concurrency | Performance Engineer, Distributed Systems Reviewer, SRE |
+| Infrastructure, deployment, migration | DevOps Reviewer, SRE, Rollback Reviewer |
+| Documentation, knowledge systems | Information Architecture Reviewer, Reader Experience Reviewer |
+| Skills, prompts, workflows | Skill Design Reviewer, Trigger/Evaluation Reviewer, Process Reliability Reviewer |
+
+## Domain Expert Construction Protocol
+
+When the task is in a vertical domain, construct role cards instead of relying only on the universal lenses.
+
+Algorithm:
+1. Identify the domain and subdomain.
+2. Extract 3-7 domain success criteria.
+3. Extract 3-7 domain failure modes.
+4. Map the highest-impact failure modes to expert lenses.
+5. Add one execution or implementation expert.
+6. Add one evidence or risk expert when claims are uncertain.
+7. Cap the panel at 5 experts.
+8. If confidence is low, ask the user to confirm or adjust the proposed panel.
+
+Role card format:
+
+```markdown
+## Expert Role Card
+- Title:
+- Domain:
+- Review Lens:
+- Failure Modes to Catch:
+- Evidence Standard:
+- Typical Blind Spots:
+- What This Expert Must Not Do:
+```
+
+## Confidence Gate
+
+Ask the user to confirm the panel when:
+- The domain has specialized success criteria the agent cannot infer.
+- Regulatory, financial, medical, legal, safety, or other high-stakes expertise is central.
+- The panel would otherwise rely mostly on `[unknown]` or generic judgment.
+- The user likely has domain knowledge that can materially improve role selection.
+
+Suggested question:
+
+```markdown
+I can construct a domain-specific expert panel, but I need to confirm the domain's evaluation standard. Which success criteria matter most here?
+A. Growth or return
+B. Risk control
+C. User or reader experience
+D. Feasibility and execution
+E. Long-term impact
+F. Other
+```
+
+## Examples
+
+### Financial Investment
+
+Possible panel:
+- Portfolio Risk Reviewer: position sizing, drawdown, correlation, tail risk.
+- Fundamental / Valuation Reviewer: valuation assumptions, earnings quality, cycle position.
+- Market Structure Reviewer: liquidity, transaction costs, crowded trades, reflexivity.
+- Regulatory / Compliance Reviewer: suitability, restrictions, disclosure, legal boundaries.
+- Behavioral Risk Reviewer: confirmation bias, narrative traps, historical overfitting.
+
+### Xianxia Web Novel
+
+Possible panel:
+- Worldbuilding Consistency Reviewer: cultivation logic, resource economy, faction structure.
+- Character Motivation Reviewer: desire, conflict, growth arc, emotional credibility.
+- Genre Reader Experience Reviewer: payoff rhythm, chapter hooks, expectation management.
+- Plot Architecture Reviewer: foreshadowing, escalation path, long-serialization tension.
+- Cliche / Fatigue Red Team: trope fatigue, power inflation, protagonist immunity, stale arcs.
+
+### Green Energy Commercialization
+
+Possible panel:
+- Technology Readiness Reviewer: maturity, efficiency, reliability, lifecycle.
+- Project Finance Reviewer: CAPEX, OPEX, LCOE, IRR, subsidy dependence.
+- Grid / Operations Reviewer: interconnection, curtailment, storage, maintenance.
+- Policy / Carbon Accounting Reviewer: policy cycles, carbon boundaries, compliance.
+- Deployment Red Team: scale-up gaps across supply chain, permits, local execution, business model.
+
+## Expert Output Contract
+
+```markdown
+## Role
+## Core Judgment
+## Evidence
+## Assumptions
+## Unknowns
+## Failure Modes
+## Recommended Action
+## Must-Fix / Nice-to-Have
+```
+
+## Red Team and Judge Are Not Normal Experts
+
+The red team is a separate adversarial phase. It attacks assumptions, counterexamples, incentives, metrics, cost, edge cases, security, privacy, compliance, operations, and bland compromise.
+
+The judge is also separate. It arbitrates rather than summarizes and must decide which claims are supported, which risks block action, what path is recommended, and what minimum validation is required.

--- a/skills/expert-redteam-review/references/role-library.md
+++ b/skills/expert-redteam-review/references/role-library.md
@@ -9,7 +9,7 @@ The role library is not a fixed cast. It is a set of review lenses plus a protoc
 3. **Cap serious reviews at 3-5 experts**: more usually adds synthesis noise.
 4. **Include an execution lens**: complex decisions need someone to inspect delivery, testing, operations, or maintenance.
 5. **Construct domain experts when needed**: do not force a generic role onto a specialized field.
-6. **Ask before pretending**: if domain success criteria are unclear, ask the user to confirm the panel.
+6. **Confirm before full vertical review**: for L2/L3 vertical-domain work, propose the domain-specific panel and ask the user to confirm or adjust it before running the full review, unless the user has already approved the panel.
 
 ## Universal Review Lenses
 
@@ -49,7 +49,7 @@ Algorithm:
 5. Add one execution or implementation expert.
 6. Add one evidence or risk expert when claims are uncertain.
 7. Cap the panel at 5 experts.
-8. If confidence is low, ask the user to confirm or adjust the proposed panel.
+8. For L2/L3 vertical-domain work, present the proposed panel and ask the user to confirm or adjust it before running the full review. For L1, ask when confidence is low or the user's domain knowledge could materially improve role selection.
 
 Role card format:
 
@@ -64,9 +64,9 @@ Role card format:
 - What This Expert Must Not Do:
 ```
 
-## Confidence Gate
+## Panel Confirmation Gate
 
-Ask the user to confirm the panel when:
+For L2/L3 vertical-domain work, ask the user to confirm or adjust the proposed panel before running the full review. This prevents the review from locking onto the wrong domain standard. For L1, ask when:
 - The domain has specialized success criteria the agent cannot infer.
 - Regulatory, financial, medical, legal, safety, or other high-stakes expertise is central.
 - The panel would otherwise rely mostly on `[unknown]` or generic judgment.
@@ -75,13 +75,14 @@ Ask the user to confirm the panel when:
 Suggested question:
 
 ```markdown
-I can construct a domain-specific expert panel, but I need to confirm the domain's evaluation standard. Which success criteria matter most here?
-A. Growth or return
-B. Risk control
-C. User or reader experience
-D. Feasibility and execution
-E. Long-term impact
-F. Other
+I propose this domain-specific expert panel before running the full review:
+- {expert_1}: {lens_1}
+- {expert_2}: {lens_2}
+- {expert_3}: {lens_3}
+- {expert_4}: {lens_4}
+- {expert_5}: {lens_5}
+
+Please confirm, remove, or adjust these roles. If the domain's success criteria differ from my assumptions, tell me which criteria matter most before I run the L2/L3 review.
 ```
 
 ## Examples

--- a/skills/expert-redteam-review/references/surge-integration.md
+++ b/skills/expert-redteam-review/references/surge-integration.md
@@ -1,0 +1,118 @@
+# Optional surge Integration
+
+This skill is independent and general-purpose. surge must not depend on it. If the skill is unavailable, surge should continue with its native expert review, design, QA, and convergence mechanisms.
+
+## Relationship
+
+| Capability | surge Native Expert Review | expert-redteam-review |
+|---|---|---|
+| Primary goal | Delivery-oriented iterative completion. | Decision-quality review for complex choices. |
+| Review focus | Candidate scoring and design constraints. | Assumption attack, rebuttal, arbitration, validation. |
+| Scope | surge design and QA phases. | Any high-impact decision point. |
+| Output | Synthesis and constraints for iteration. | Decision package and minimum validation action. |
+| Dependency | Internal to surge. | Optional external enhancement. |
+
+## Optional Use Criteria
+
+The preferred placement is after surge has produced candidate options or after QA exposes a design-rooted risk. Do not run this skill before surge has a concrete decision point to review.
+
+surge may use this skill only when one or more are true:
+- The user explicitly asks for an expert panel, red-team challenge, rebuttal, or judge.
+- The design phase has multiple high-risk candidate solutions.
+- Native expert reviews disagree severely and a decision must be arbitrated.
+- QA finds P0/P1 issues caused by design-level assumptions rather than implementation defects.
+- The task has one-way-door characteristics: production release, data migration, security/privacy/compliance exposure, broad refactor, external publication, or financial exposure.
+
+Do not use it for:
+- Normal delivery iteration.
+- Low-risk changes.
+- Work that has already converged.
+- Cases where token budget is tight and the risk profile is low.
+- Tasks where implementation is the only remaining step.
+
+## Non-Dependency Rule
+
+surge documentation may say:
+
+```markdown
+If an `expert-redteam-review` skill is available and the task meets high-risk decision criteria, the Director may use it as an optional review checkpoint. If unavailable, continue with surge's native expert-review flow.
+```
+
+This skill must not require surge to change:
+- state schema
+- trace schema
+- scripts
+- task directory layout
+- convergence rules
+
+## Minimum Input Package from surge
+
+Pass summaries and paths, not entire artifacts.
+
+```markdown
+## Surge Context Summary
+- task_id:
+- current_phase:
+- iteration:
+- deliverable_type:
+- decision_point:
+- candidate_options:
+- current_recommendation:
+- known_constraints:
+- acceptance_criteria:
+- open_risks:
+- relevant_file_paths:
+```
+
+Rules:
+- State the exact decision point.
+- Pass candidate option summaries, not full designs.
+- Pass file paths for source artifacts; read details only when needed.
+- Do not ask the red team to attack the whole project if only one decision is under review.
+- Keep the decision brief under 1-2 pages when possible.
+
+## Output Back to surge
+
+The decision package may include a surge-specific section:
+
+```markdown
+### Suggested surge Integration
+- design_constraints:
+- qa_acceptance_additions:
+- implementation_warnings:
+- rollback_or_checkpoint_notes:
+- optimization_directives:
+```
+
+surge may choose to incorporate these into:
+- `iter_{NN}_design.md` as design constraints.
+- `acceptance.md` as acceptance additions.
+- `state.md` as optimization directives or risk notes.
+- `context.md` as user-confirmed clarifications.
+- `iter_{NN}_qa.md` as risk interpretation.
+
+These are suggestions. The surge Director remains responsible for state updates and convergence decisions.
+
+## Veto and Severity Mapping
+
+| expert-redteam-review | Suggested surge Handling |
+|---|---|
+| P0 | Treat like a veto. Return to design or ask for explicit user override. |
+| P1 | Add to design constraints or acceptance criteria before implementation continues. |
+| P2 | Record as residual risk and monitor during QA. |
+| P3 | Add to optimization backlog if useful. |
+
+A P0 is not a permanent ban. The user can override it, but must explicitly acknowledge the risk.
+
+## Token Budget
+
+Use three layers:
+1. **Decision brief**: required, compact summary.
+2. **Referenced files**: paths only, read on demand.
+3. **Full artifacts**: avoid unless needed for a disputed or high-impact claim.
+
+Experts receive only the context relevant to their role. Red team receives the synthesis rather than every raw expert answer. Judge receives context package, synthesis, red-team findings, and rebuttal summary.
+
+## Recommended surge Patch Scope
+
+If the repository wants surge to mention this skill, make only a small optional note in surge's expert review or design references. Do not make startup, state, scripts, or QA require this skill.

--- a/skills/expert-redteam-review/references/templates.md
+++ b/skills/expert-redteam-review/references/templates.md
@@ -1,0 +1,245 @@
+# Templates
+
+Use these templates only when structure improves decision quality. Compress them for L0/L1.
+
+## Context Package
+
+```markdown
+## Decision Point
+
+## Scope
+
+## Non-Goals
+
+## Hard Constraints
+
+## Decision Type
+- one-way door / two-way door:
+- execution risk:
+
+## Success Criteria
+
+## Evidence Policy
+
+## Known Unknowns
+
+## Output Target
+```
+
+## Expert Prompt
+
+```markdown
+You are the {role_title}.
+
+## Role Card
+- Domain: {domain}
+- Review Lens: {review_lens}
+- Failure Modes to Catch: {failure_modes}
+- Evidence Standard: {evidence_standard}
+- What This Expert Must Not Do: {must_not_do}
+
+## Context Package
+{context_package}
+
+## Your Task
+Provide an independent judgment. Do not optimize for consensus. State weak evidence, uncertainty, and disagreement clearly.
+
+## Output Format
+### Role
+### Core Judgment
+### Evidence
+Use evidence labels: [source], [code], [test], [data], [inference], [engineering-judgment], [creative-judgment], [unknown].
+### Assumptions
+### Unknowns
+### Failure Modes
+### Recommended Action
+### Must-Fix / Nice-to-Have
+```
+
+## Expert Synthesis Template
+
+```markdown
+## Expert Synthesis
+
+### Selected Experts
+| Expert | Why Selected | Main Lens |
+|---|---|---|
+
+### Judgment Matrix
+| Expert | Core Judgment | Evidence Level | Main Concern | Recommendation |
+|---|---|---|---|---|
+
+### Consensus
+
+### Disagreements That Affect the Decision
+
+### Unsupported or Weak Claims
+
+### Issues to Send to Red Team
+```
+
+## Red-Team Prompt
+
+```markdown
+You are the red team. Your role is not to be balanced; it is to find how this decision can fail.
+
+## Inputs
+- Context package
+- Expert synthesis
+- Current recommendation
+
+## Attack Surface
+Challenge:
+- invalid assumptions
+- counterexamples
+- incentive mismatch
+- metric gaming or Goodhart risk
+- edge cases and boundary conditions
+- cost, schedule, and maintenance underestimation
+- safety, security, privacy, legal, compliance, or operational risk
+- bland compromise that removes the actual strategic choice
+- vertical-domain failure modes missed by generic reviewers
+
+Classify every finding:
+- P0: blocks the proposal or can cause major failure
+- P1: must be resolved before execution
+- P2: acceptable only with explicit risk record
+- P3: improvement suggestion
+
+For every P0/P1, provide a minimum fix.
+```
+
+## Red-Team Output
+
+```markdown
+## Attack Summary
+
+## P0 Findings
+- Finding:
+- Evidence:
+- Minimum Fix:
+
+## P1 Findings
+- Finding:
+- Evidence:
+- Minimum Fix:
+
+## P2 Findings
+- Finding:
+- Why It May Be Acceptable:
+- Monitoring / Risk Record:
+
+## P3 Findings
+
+## Residual Risks
+```
+
+## Rebuttal Prompt
+
+```markdown
+You are the {role_title}. Respond only to red-team findings relevant to your domain. A finding is relevant when it depends on your domain assumptions, changes your recommendation, or requires your domain's mitigation.
+
+For each relevant finding, mark one status:
+- accepted
+- mitigated
+- disputed
+- deferred
+
+Include the reason, the evidence label, and any required change to the recommendation.
+```
+
+## Rebuttal Output
+
+```markdown
+## Rebuttal by {role_title}
+
+| Finding | Status | Response | Required Change |
+|---|---|---|---|
+```
+
+## Judge Prompt
+
+```markdown
+You are the judge. Do not average opinions and do not merely summarize.
+
+## Inputs
+- Context package
+- Expert synthesis
+- Red-team findings
+- Rebuttals
+
+## Arbitration Criteria
+- impact
+- confidence
+- reversibility
+- evidence quality
+- implementation cost
+- time to learn
+- blast radius
+- user or stakeholder value
+
+## Required Decision
+1. final judgment
+2. recommended path
+3. rejected alternatives
+4. must-fix issues
+5. accepted residual risks
+6. deferred questions
+7. minimum validation action
+8. human gate required or not
+```
+
+## L2/L3 Decision Package
+
+```markdown
+## Expert Red-Team Decision Package
+
+### Final Judgment
+Continue / continue after changes / pause / abandon / gather more evidence.
+
+### Decision Context
+- Decision point:
+- Scope:
+- Non-goals:
+- Hard constraints:
+- Success criteria:
+- Evidence standard:
+
+### Expert Panel
+| Expert | Core Judgment | Evidence Level | Main Concern | Recommendation |
+|---|---|---|---|---|
+
+### Consensus
+
+### Disagreements
+
+### Red-Team Findings
+#### P0 Blocking
+#### P1 Must Fix
+#### P2 Residual Risk
+#### P3 Improvements
+
+### Rebuttals
+| Finding | Status | Response | Required Change |
+|---|---|---|---|
+
+### Judge Arbitration
+- Supported claims:
+- Weak or speculative claims:
+- Blocking risks:
+- Accepted risks:
+- Rejected alternatives:
+
+### Recommended Path
+
+### Must-Fix Before Proceeding
+
+### Minimum Validation Action
+
+### Human Gate
+Status: Required / Not Required
+Reason:
+Approval Needed For:
+
+### Files Created or Changed
+```

--- a/skills/expert-redteam-review/references/workflow.md
+++ b/skills/expert-redteam-review/references/workflow.md
@@ -1,0 +1,156 @@
+# Expert Red-Team Workflow
+
+This reference defines the scalable workflow. Use the smallest level that can produce a reliable decision.
+
+## L0: Quick Red-Team Check
+
+Use L0 when the user wants a fast challenge, a sanity check, or a concise adversarial pass.
+
+Steps:
+1. Identify the decision point.
+2. State assumptions and constraints.
+3. Challenge the proposal from value, feasibility, and risk perspectives.
+4. Classify serious issues as P0/P1/P2/P3.
+5. Give a concise recommendation and minimum validation action.
+
+Output:
+
+```markdown
+## Quick Red-Team Check
+
+### Main Vulnerability
+### Must-Fix Before Action
+### Acceptable Risks
+### Minimum Validation
+### Recommendation
+```
+
+Do not dispatch subagents for L0.
+
+## L1: Small Expert Review
+
+Use L1 when multiple perspectives are useful but formal adversarial review would be excessive.
+
+Steps:
+1. Build a compact context package.
+2. Choose 2-3 orthogonal expert roles.
+3. Run independent expert judgments.
+4. Synthesize consensus and disagreements.
+5. Recommend a path and minimum validation action.
+
+Output:
+
+```markdown
+## Expert Review Summary
+
+### Context
+### Selected Experts
+### Expert Judgments
+| Expert | Judgment | Evidence Level | Key Risk | Recommendation |
+|---|---|---|---|---|
+
+### Consensus
+### Disagreements
+### Recommended Path
+### Minimum Validation
+```
+
+Use real subagents when the environment supports delegation and independent context matters. Otherwise simulate roles sequentially with strict section separation.
+
+## L2: Full Expert Panel + Red Team
+
+Use L2 when the user asks for an expert panel, red team, rebuttal, or judge, or when the decision is ambiguous, cross-functional, high-impact, or likely to suffer from hidden assumptions.
+
+Steps:
+1. **Triage**: define the decision, reversibility, risk level, and output target.
+2. **Context package**: capture scope, non-goals, constraints, success criteria, evidence policy, and known unknowns.
+3. **Expert panel**: choose 3-5 orthogonal roles. Experts produce independent judgments.
+4. **Synthesis**: summarize consensus briefly, then emphasize disagreements and weak evidence.
+5. **Red team**: attack assumptions, incentives, metrics, cost, edge cases, security, privacy, compliance, operations, and bland compromises.
+6. **Rebuttal**: only experts touched by a finding respond. Mark each finding `accepted`, `mitigated`, `disputed`, or `deferred`.
+7. **Judge**: arbitrate supported claims, weak claims, blocking risks, accepted risks, rejected alternatives, and the recommended path. The judge should use the record, not loyalty to the initial recommendation.
+8. **Decision package**: produce an actionable result.
+
+Output:
+
+```markdown
+## Expert Red-Team Decision Package
+
+### Final Judgment
+### Decision Context
+### Expert Panel
+### Consensus
+### Disagreements
+### Red-Team Findings
+#### P0 Blocking
+#### P1 Must Fix
+#### P2 Residual Risk
+#### P3 Improvements
+### Rebuttals
+### Judge Arbitration
+### Recommended Path
+### Must-Fix Before Proceeding
+### Minimum Validation Action
+### Human Gate
+### Files Created or Changed
+```
+
+## L3: Gated Review
+
+Use L3 for one-way-door or high-blast-radius decisions, including production releases, data migrations, financial exposure, privacy/security/compliance risks, external publication, permission changes, or destructive actions.
+
+L3 is L2 plus:
+- Explicit one-way-door / two-way-door classification.
+- Human approval before execution.
+- A rollback or containment note when rollback is possible.
+- A recommendation that does not execute the risky action until approved.
+
+Human gate format:
+
+```markdown
+### Human Gate
+Status: Required
+Reason: [irreversible / production / security / privacy / compliance / financial / external-facing / destructive]
+Approval Needed For: [specific action]
+Do Not Execute Until: the user explicitly approves this action.
+```
+
+## Escalation and Downshift Rules
+
+Escalate when:
+- L0 finds a P0/P1 issue.
+- L1 experts strongly disagree on the recommended path.
+- The task involves one-way-door execution.
+- Evidence is weak but consequences are high.
+
+Downshift when:
+- The user asks for speed and risk is low.
+- The task is a simple implementation detail.
+- The decision is already made and only execution remains.
+- The panel would repeat obvious points rather than improve judgment.
+
+## Red-Team Severity
+
+| Severity | Meaning | Required Handling |
+|---|---|---|
+| P0 | Blocks the proposal or can cause major failure. | Do not proceed without redesign or explicit user override. |
+| P1 | Must be resolved before execution. | Provide a minimum fix. |
+| P2 | Acceptable only if recorded and monitored. | Explain why it is acceptable. |
+| P3 | Improvement suggestion. | Do not present as a blocker. |
+
+Every P0/P1 requires a minimum fix. If the review cannot identify a fix, say so and recommend more discovery before action.
+
+## Evidence Policy
+
+Use these labels for important claims:
+
+- `[source]`: external source or authoritative document.
+- `[code]`: current code or repository file.
+- `[test]`: test, build, benchmark, or runtime verification.
+- `[data]`: dataset, metric, telemetry, financial model, or measurement.
+- `[inference]`: reasoning from stated facts.
+- `[engineering-judgment]`: engineering experience or heuristic.
+- `[creative-judgment]`: creative, editorial, aesthetic, or audience-experience judgment.
+- `[unknown]`: important but currently unsupported.
+
+The judge should not treat all labels equally. A high-confidence decision should rely on evidence appropriate to the domain.

--- a/skills/surge/references/expert-review.md
+++ b/skills/surge/references/expert-review.md
@@ -171,6 +171,65 @@ After viewing the synthesis report, the Director presents:
 - **Veto is advisory** — the user CAN select a vetoed solution if they explicitly acknowledge the flagged risks
 - Multiple experts may veto the same solution for different reasons; all reasons are listed
 
+## Optional Adversarial Decision Review
+
+If an `expert-redteam-review` skill is available and the task meets high-risk decision criteria, the Director MAY use it as an optional checkpoint after surge has concrete candidate options or after QA exposes a design-rooted risk. If unavailable, continue with surge's native expert-review flow.
+
+Use this optional checkpoint only when one or more are true:
+- The user explicitly asks for an expert panel, red-team challenge, rebuttal, judge, or adversarial arbitration.
+- Candidate solutions are high-risk and differ on architecture, data, security, compliance, production rollout, or irreversible direction.
+- Native expert reviews disagree severely and the Director needs arbitration rather than another scoring pass.
+- QA finds P0/P1 issues caused by design-level assumptions rather than implementation defects.
+- The task has one-way-door characteristics: production release, data migration, security/privacy/compliance exposure, broad refactor, external publication, or financial exposure.
+
+Do not use it for routine delivery iteration, low-risk changes, work that has already converged, token-constrained low-risk cases, or tasks where implementation is the only remaining step.
+
+### Non-Dependency Rules
+
+- `expert-redteam-review` is an optional enhancement, not a surge dependency.
+- Do not change state schema, trace schema, scripts, task directory layout, or convergence rules to require it.
+- If the skill is missing, disabled, or unsuitable, continue with this native expert-review process.
+- The surge Director remains responsible for state updates, checkpoint decisions, and convergence.
+
+### Minimum Input Package
+
+Pass summaries and paths, not full artifacts:
+
+```markdown
+## Surge Context Summary
+- task_id:
+- current_phase: design / qa / convergence
+- iteration:
+- deliverable_type:
+- decision_point:
+- candidate_options:
+- current_recommendation:
+- known_constraints:
+- acceptance_criteria:
+- open_risks:
+- relevant_file_paths:
+```
+
+Rules:
+- State the exact decision point under review.
+- Pass candidate option summaries, not full designs.
+- Pass file paths for source artifacts so details can be read on demand.
+- Do not ask the red team to attack the whole project if only one decision is under review.
+
+### Output Mapping Back to surge
+
+If the optional checkpoint returns a decision package, map it back as suggestions:
+
+| expert-redteam-review Output | Suggested surge Handling |
+|---|---|
+| P0 blocking issue | Treat like a veto: return to design or ask for explicit user override. |
+| P1 must-fix issue | Add to design constraints or acceptance criteria before implementation continues. |
+| P2 residual risk | Record as residual risk and monitor during QA. |
+| P3 improvement | Add to optimization backlog only if useful. |
+| Minimum validation action | Add to acceptance criteria, QA plan, or checkpoint notes. |
+
+A P0 is not a permanent ban. The user can override it, but must explicitly acknowledge the flagged risk.
+
 ### Error Handling
 
 - If an expert subagent fails (timeout, malformed output), the Director retries once


### PR DESCRIPTION
## Summary
- add a provider-agnostic expert-redteam-review skill for expert panels, red-team challenges, rebuttals, and judge arbitration
- require vertical-domain panel confirmation before full L2/L3 reviews
- document optional surge integration without making it a hard dependency

## Validation
- verified skill files are ASCII-only and provider-agnostic
- ran evals for payment migration, xianxia panel, and surge integration
- verified surge optional integration markers