### PR TITLE
feat: add domain-sensemaking skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ git clone https://github.com/carbonshow/intent-fluid.git
 | [surge](skills/surge/) | Autonomous delivery system — iterative analyze/research/design/implement/QA cycles driven by a Director Agent. Provide a PRD to activate. |
 | [slidev](skills/slidev/) | Lightweight Markdown-based presentations — intelligently analyzes content, auto-selects layouts (text, diagrams, tables, images), generates Mermaid flowcharts, and applies adaptive density controls to prevent overflow. A faster, code-native alternative to heavy slide tools. |
 | [expert-redteam-review](skills/expert-redteam-review/) | Expert panel + red-team review workflow for complex decisions — scopes the decision, assembles domain experts, challenges assumptions, supports rebuttals, and produces judge arbitration with minimum validation actions. |
+| [domain-sensemaking](skills/domain-sensemaking/) | Structured research workflow for unfamiliar domains — frames the problem, generates and ranks exploration frontiers, builds concept/claim/evidence graphs, checks convergence, then synthesizes a traceable conclusion. Supports Learning, Research/Engineering, and Consulting/Decision modes. |
 
 ### Creating a New Skill
 

--- a/skills/domain-sensemaking/SKILL.md
+++ b/skills/domain-sensemaking/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: domain-sensemaking
+description: "Use proactively when the user needs to make sense of an unfamiliar, ambiguous, complex, or messy domain before acting. Trigger not only on explicit requests like deep research, exploratory search, sensemaking, knowledge graph learning, frontier exploration, research workflow, evidence synthesis, or industry consulting, but also on vague questions, 'I do not know where to start', learning plans, market/industry/technology/product trend analysis, competitor/user/interview/observation synthesis, scientific or engineering investigation design, hypothesis generation, theory building, decision framing, strategy memo creation, and situations where the task requires iteratively reframing the question, ranking what to explore next, building concept/claim/evidence relationships, or deriving an actionable conclusion from incomplete information. Do not use for simple fact lookup, narrow one-shot Q&A, or tasks with an already fixed implementation path."
+---
+
+# Domain Sensemaking
+
+Use this skill to convert a vague question into an iterative research workflow: frame the problem, generate and rank exploration frontiers, collect evidence, build a concept/claim graph, reframe the question, test convergence, then synthesize a traceable conclusion.
+
+This skill is platform-neutral. Use whatever capabilities are available: local files, user-provided notes, web search, papers, databases, interviews, code experiments, or only dialogue. If a platform lacks browsing, file writes, or subagents, continue with explicit assumptions and ask for the missing inputs.
+
+## Deterministic Helpers
+
+When a filesystem and Python are available, use the bundled `scripts/sensemaking_helper.py` for fixed-format work instead of recreating tables manually:
+
+```bash
+python scripts/sensemaking_helper.py init --output path/to/workspace --question "..." --mode Learning
+python scripts/sensemaking_helper.py score-frontier path/to/frontier.csv --format markdown
+python scripts/sensemaking_helper.py check-convergence path/to/convergence.csv
+```
+
+All paths above are relative to this skill's directory. Resolve them against the skill's installed location before executing.
+
+- Use `init` at the start of substantial research to create a problem card, frontier queue, relationship tables, convergence checklist, and synthesis scaffold.
+- Use `score-frontier` whenever candidate nodes have `impact`, `uncertainty`, `explorability`, and `cost` scores.
+- Use `check-convergence` before final synthesis to avoid ending with an unchecked narrative.
+- If scripts cannot run, follow `references/templates.md` manually and keep the same fields.
+
+## Core Rules
+
+- Treat LLM output as candidate structure or hypotheses, not evidence.
+- Separate `source`, `claim`, `evidence`, and `inference`. Never conflate them.
+- Preserve question evolution. Do not silently replace the initial question with a cleaner one.
+- Prefer a small explicit knowledge graph over a long reading list.
+- Rank the next frontier before continuing exploration.
+- Stop exploration when evidence can support a decision, explanation, experiment, or synthesis; do not optimize for completeness.
+- For time-sensitive, financial, legal, medical, scientific, or business-critical facts, verify with primary or current sources when available.
+
+## Mode Selection
+
+Choose one primary mode before exploring:
+
+| Mode | Use when | Primary output |
+|---|---|---|
+| Learning | The user wants to understand a mature or emerging domain | mental model, concept map, competency questions |
+| Research / Engineering | The user needs a hypothesis, design, experiment, or technical plan | testable hypotheses, design space, validation plan |
+| Consulting / Decision | The user must act on messy market, business, user, or competitor signals | recommendation, assumptions, scenarios, monitoring signals |
+
+If the user does not specify the mode, infer it from the requested output. If still unclear, default to Learning for understanding questions and Consulting / Decision for business action questions.
+
+## Workflow
+
+**Write-through rule**: every step produces files, not just conversation text. When a workspace exists, write each artifact (problem card, frontier CSV, node exploration notes, relation/claim/contradiction tables, convergence CSV, final synthesis) to the workspace **immediately after completing that step** before moving on. Keeping results only in the conversation is not acceptable — the workspace is the single source of truth and must stay up to date so that later steps (and the helper scripts) can read from it.
+
+### 0. Frame the Problem
+
+Run `init` to create the workspace, then **immediately fill in** the generated `problem-card.md` with concrete content before proceeding to Step 1. Do not leave placeholder fields empty — populate every section (uncertainties, known facts, hypotheses, constraints, convergence criteria) now, based on the user's question and whatever context is available. The filled problem card is the input to frontier generation; an empty template has no value.
+
+Create a problem card before searching:
+
+- `initial_question`: raw user question.
+- `mode`: Learning, Research / Engineering, or Consulting / Decision.
+- `target_output`: what the user needs at the end.
+- `core_uncertainties`: 3-7 unknowns that can change the conclusion.
+- `known_facts`: confirmed context.
+- `initial_hypotheses`: plausible but unproven beliefs.
+- `constraints`: time, data, scope, cost, permissions, business boundary.
+- `draft_convergence_criteria`: what would be enough to stop.
+
+### 1. Build the Initial Frontier
+
+Generate a first frontier from the problem card, then **write the nodes to `frontier.csv`** with scores. Use `score-frontier` to rank them and overwrite the CSV with sorted results. Classify nodes instead of listing undifferentiated keywords:
+
+- `concept`: terms, theories, mechanisms, models.
+- `variable`: factors, metrics, constraints, drivers.
+- `method`: solution patterns, algorithms, procedures, tools.
+- `evidence`: papers, reports, datasets, interviews, observations.
+- `case`: companies, incidents, products, historical examples.
+- `controversy`: conflicting claims or interpretations.
+- `hypothesis`: falsifiable assumptions.
+- `decision`: action-relevant judgment points.
+
+For each node, write the uncertainty it is meant to reduce.
+
+### 2. Explore Nodes
+
+For each selected frontier node, collect four outputs and **save each exploration as a separate file** in the workspace (e.g., `node-1-name.md`):
+
+1. Definition: what it is and what it is not.
+2. Structure: related concepts, variables, methods, cases, and dependencies.
+3. Evidence: supporting and opposing sources, with reliability notes.
+4. Implication: how this changes the question, hypotheses, or next frontier.
+
+Use breadth-first exploration for the first map, then depth-first exploration for high-impact nodes.
+
+### 3. Engineer the Knowledge
+
+Maintain three working tables and **write them to `relations.csv`, `claims.csv`, and `contradictions.csv`** as you go. Update these files incrementally after each exploration round, not just at the end:
+
+- Concept relation table: `A`, `relation`, `B`, `note`.
+- Claim-evidence table: `claim`, `supporting_evidence`, `opposing_evidence`, `confidence`.
+- Contradiction/gap table: `type`, `content`, `next_action`.
+
+Use relation labels such as `is-a`, `part-of`, `depends-on`, `causes`, `enables`, `contrasts-with`, `evolves-from`, `used-for`, and `failure-mode-of`.
+
+### 4. Reframe the Question
+
+After each exploration round, rewrite the question and explain why:
+
+- Broad question -> sub-question.
+- Concept question -> mechanism question.
+- Open question -> decision question.
+- Single-cause question -> system question.
+
+Keep the original question visible so the final synthesis can explain how the investigation evolved.
+
+### 5. Check Convergence
+
+Update `convergence.csv` with the current status of each check, then run `check-convergence` to verify. Converge only when all relevant checks pass:
+
+- The question is now specific enough to answer.
+- The main concept/variable/claim graph has no critical isolated nodes.
+- Key disagreements can be explained.
+- Important claims have enough evidence or are explicitly marked uncertain.
+- A decision, explanation, experiment, or next action can be derived.
+- New exploration mostly repeats known nodes or does not change the conclusion.
+
+If checks fail, return to frontier ranking (step 6).
+
+### 6. Rank the Next Frontier
+
+Do not continue by asking for "more related topics." Score candidate nodes:
+
+```text
+frontier_score = impact * uncertainty * explorability / exploration_cost
+```
+
+Prioritize nodes that can change the final conclusion, are currently uncertain, can be explored with available methods, and have acceptable cost. Defer low-impact or untestable nodes.
+
+### 7. Synthesize
+
+Write the final output to `final-synthesis.md`. The final output is a reasoned argument, not a source dump:
+
+- Restate the initial question.
+- Show how the question was reframed.
+- Summarize explored nodes and why they mattered.
+- Present the concept/variable/claim graph in text or table form.
+- State core claims with evidence and confidence.
+- Explain contradictions and remaining unknowns.
+- Answer the question.
+- Provide mode-specific next actions.
+
+For reusable table templates, output contracts, and mode-specific checklists, read `references/templates.md`.
+
+## Persistence
+
+When operating inside a knowledge base or project, save substantial results to the appropriate durable location and link them into the local index. When no file system is available, return a self-contained artifact that the user can store manually.

--- a/skills/domain-sensemaking/references/templates.md
+++ b/skills/domain-sensemaking/references/templates.md
@@ -1,0 +1,186 @@
+# Domain Sensemaking Templates
+
+Use these templates when the user asks for a concrete workflow artifact or when the research is substantial enough to need traceability.
+
+If a local runtime is available, prefer generating these files with:
+
+```bash
+python scripts/sensemaking_helper.py init --output path/to/workspace --question "..."
+```
+
+## Problem Card
+
+```markdown
+# Problem Card
+
+Initial question:
+Current reframing:
+Mode:
+Target output:
+
+Core uncertainties:
+- U1:
+- U2:
+- U3:
+
+Known facts:
+-
+
+Initial hypotheses:
+- H1:
+- H2:
+
+Constraints:
+- Time:
+- Data:
+- Scope:
+- Business/engineering boundary:
+
+Draft convergence criteria:
+-
+```
+
+## Frontier Queue
+
+```markdown
+| Node | Type | Exploration purpose | Impact | Uncertainty | Explorability | Cost | Priority |
+|---|---|---|---:|---:|---:|---:|---:|
+|  | concept / variable / method / evidence / case / controversy / hypothesis / decision |  |  |  |  |  |  |
+```
+
+Use a 1-5 score for `Impact`, `Uncertainty`, `Explorability`, and `Cost`. Higher `Cost` lowers priority.
+
+## Node Exploration Note
+
+```markdown
+## Node:
+
+Type:
+Exploration purpose:
+
+### Definition
+
+### Structure
+- Related concepts:
+- Related variables:
+- Related methods:
+- Related cases:
+- Dependencies:
+
+### Evidence
+| Source | Claim | Evidence type | Reliability | Notes |
+|---|---|---|---|---|
+
+### Implication
+- Question update:
+- Hypothesis update:
+- New frontier candidates:
+```
+
+## Concept Relation Table
+
+```markdown
+| A | Relation | B | Note |
+|---|---|---|---|
+|  | is-a / part-of / depends-on / causes / enables / contrasts-with / evolves-from / used-for / failure-mode-of |  |  |
+```
+
+## Claim-Evidence Table
+
+```markdown
+| Claim | Supporting evidence | Opposing evidence | Confidence | Decision relevance |
+|---|---|---|---|---|
+|  |  |  | high / medium / low |  |
+```
+
+Confidence guidance:
+
+- `high`: multiple reliable sources or direct data support the claim; counterevidence is weak or explained.
+- `medium`: plausible and supported, but limited by source quality, sample size, or unresolved assumptions.
+- `low`: useful hypothesis, but evidence is thin, indirect, outdated, or mostly inferred.
+
+## Contradiction And Gap Table
+
+```markdown
+| Type | Content | Likely cause | Next action |
+|---|---|---|---|
+| contradiction / gap / isolated-node / assumption |  | definition / sample / time window / incentive / missing data / unknown |  |
+```
+
+## Convergence Checklist
+
+```markdown
+| Check | Status | Evidence |
+|---|---|---|
+| Question is specific enough to answer | pass / fail |  |
+| Main graph has no critical isolated nodes | pass / fail |  |
+| Key disagreements can be explained | pass / fail |  |
+| Important claims have sufficient evidence or explicit uncertainty labels | pass / fail |  |
+| Decision, explanation, experiment, or action can be derived | pass / fail |  |
+| New exploration has low marginal value | pass / fail |  |
+```
+
+## Final Synthesis
+
+```markdown
+# Final Synthesis
+
+## Initial Question
+
+## Question Evolution
+
+## Research Path
+
+## Knowledge Graph Summary
+
+## Core Claims
+
+| Claim | Evidence | Confidence | Implication |
+|---|---|---|---|
+
+## Contradictions And Unknowns
+
+## Answer
+
+## Next Actions
+```
+
+## Mode-Specific Additions
+
+### Learning
+
+Add:
+
+- Core terminology.
+- Threshold concepts.
+- Competency questions.
+- Recommended learning path.
+- Self-test prompts.
+
+Converge when the user can explain the root problem, compare mainstream approaches, answer 10-20 competency questions, and place new material onto the existing map.
+
+### Research / Engineering
+
+Add:
+
+- Falsifiable hypotheses.
+- Design space.
+- Minimum validation experiment.
+- Failure modes.
+- Evaluation metrics.
+- Constraints matrix.
+
+Converge when key hypotheses are testable, the design has measurable criteria, major risks have mitigations or alternatives, and the next step can become an experiment, prototype, or engineering plan.
+
+### Consulting / Decision
+
+Add:
+
+- Decision statement.
+- Evaluation criteria.
+- Scenario analysis.
+- Sensitivity analysis.
+- Reversal signals.
+- Counterargument.
+
+Converge when the output can recommend an action, name the assumptions behind it, define signals that would change the recommendation, and convert uncertainty into monitoring or small tests.

--- a/skills/domain-sensemaking/scripts/sensemaking_helper.py
+++ b/skills/domain-sensemaking/scripts/sensemaking_helper.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+"""Deterministic helpers for the domain-sensemaking skill."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+FRONTIER_FIELDS = [
+    "node",
+    "type",
+    "exploration_purpose",
+    "impact",
+    "uncertainty",
+    "explorability",
+    "cost",
+    "priority",
+]
+
+CONVERGENCE_ROWS = [
+    "Question is specific enough to answer",
+    "Main graph has no critical isolated nodes",
+    "Key disagreements can be explained",
+    "Important claims have sufficient evidence or explicit uncertainty labels",
+    "Decision, explanation, experiment, or action can be derived",
+    "New exploration has low marginal value",
+]
+
+
+def normalize_key(value: str) -> str:
+    return value.strip().lower().replace(" ", "_").replace("-", "_")
+
+
+def read_rows(path: Path) -> list[dict[str, Any]]:
+    if path.suffix.lower() == ".json":
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(data, dict):
+            data = data.get("rows", [])
+        if not isinstance(data, list):
+            raise ValueError("JSON input must be a list or an object with a rows list.")
+        return [{normalize_key(str(k)): v for k, v in row.items()} for row in data]
+
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        return [
+            {normalize_key(str(k)): v for k, v in row.items() if k is not None}
+            for row in reader
+        ]
+
+
+def write_csv(rows: list[dict[str, Any]], fields: list[str], path: Path | None) -> None:
+    target = path.open("w", encoding="utf-8", newline="") if path else sys.stdout
+    close_target = path is not None
+    try:
+        writer = csv.DictWriter(target, fieldnames=fields, extrasaction="ignore")
+        writer.writeheader()
+        writer.writerows(rows)
+    finally:
+        if close_target:
+            target.close()
+
+
+def print_markdown_table(rows: list[dict[str, Any]], fields: list[str]) -> None:
+    print("| " + " | ".join(fields) + " |")
+    print("|" + "|".join("---" for _ in fields) + "|")
+    for row in rows:
+        values = [str(row.get(field, "")).replace("\n", " ") for field in fields]
+        print("| " + " | ".join(values) + " |")
+
+
+def parse_score(value: Any, field: str, row_index: int) -> float:
+    try:
+        score = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Row {row_index}: {field} must be a number.") from exc
+    if score < 1 or score > 5:
+        raise ValueError(f"Row {row_index}: {field} must be between 1 and 5.")
+    return score
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    output_dir = Path(args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    files = {
+        "problem-card.md": problem_card(args),
+        "frontier.csv": ",".join(FRONTIER_FIELDS) + "\n",
+        "relations.csv": "a,relation,b,note\n",
+        "claims.csv": "claim,supporting_evidence,opposing_evidence,confidence,decision_relevance\n",
+        "contradictions.csv": "type,content,likely_cause,next_action\n",
+        "convergence.csv": convergence_csv(),
+        "final-synthesis.md": final_synthesis(),
+    }
+
+    written: list[str] = []
+    for name, content in files.items():
+        path = output_dir / name
+        if path.exists() and not args.force:
+            raise FileExistsError(f"{path} already exists. Use --force to overwrite.")
+        path.write_text(content, encoding="utf-8")
+        written.append(str(path))
+
+    print("Created domain-sensemaking workspace:")
+    for path in written:
+        print(f"- {path}")
+    return 0
+
+
+def problem_card(args: argparse.Namespace) -> str:
+    return f"""# Problem Card
+
+Initial question: {args.question or ""}
+Current reframing:
+Mode: {args.mode}
+Target output: {args.target_output or ""}
+
+Core uncertainties:
+- U1:
+- U2:
+- U3:
+
+Known facts:
+-
+
+Initial hypotheses:
+- H1:
+- H2:
+
+Constraints:
+- Time:
+- Data:
+- Scope:
+- Business/engineering boundary:
+
+Draft convergence criteria:
+-
+"""
+
+
+def convergence_csv() -> str:
+    lines = ["check,status,evidence"]
+    lines.extend(f'"{check}",fail,' for check in CONVERGENCE_ROWS)
+    return "\n".join(lines) + "\n"
+
+
+def final_synthesis() -> str:
+    return """# Final Synthesis
+
+## Initial Question
+
+## Question Evolution
+
+## Research Path
+
+## Knowledge Graph Summary
+
+## Core Claims
+
+| Claim | Evidence | Confidence | Implication |
+|---|---|---|---|
+
+## Contradictions And Unknowns
+
+## Answer
+
+## Next Actions
+"""
+
+
+def cmd_score_frontier(args: argparse.Namespace) -> int:
+    rows = read_rows(Path(args.input))
+    scored: list[dict[str, Any]] = []
+
+    for index, row in enumerate(rows, start=1):
+        impact = parse_score(row.get("impact"), "impact", index)
+        uncertainty = parse_score(row.get("uncertainty"), "uncertainty", index)
+        explorability = parse_score(row.get("explorability"), "explorability", index)
+        cost = parse_score(row.get("cost"), "cost", index)
+        priority = round((impact * uncertainty * explorability) / cost, 2)
+
+        normalized = {
+            "node": row.get("node", ""),
+            "type": row.get("type", ""),
+            "exploration_purpose": row.get("exploration_purpose", ""),
+            "impact": int(impact) if impact.is_integer() else impact,
+            "uncertainty": int(uncertainty) if uncertainty.is_integer() else uncertainty,
+            "explorability": int(explorability) if explorability.is_integer() else explorability,
+            "cost": int(cost) if cost.is_integer() else cost,
+            "priority": priority,
+        }
+        scored.append(normalized)
+
+    scored.sort(key=lambda row: float(row["priority"]), reverse=True)
+    if args.top:
+        scored = scored[: args.top]
+
+    output_path = Path(args.output) if args.output else None
+    if args.format == "json":
+        text = json.dumps(scored, ensure_ascii=False, indent=2)
+        if output_path:
+            output_path.write_text(text + "\n", encoding="utf-8")
+        else:
+            print(text)
+    elif args.format == "csv":
+        write_csv(scored, FRONTIER_FIELDS, output_path)
+    else:
+        if output_path:
+            with output_path.open("w", encoding="utf-8") as handle:
+                stdout = sys.stdout
+                sys.stdout = handle
+                try:
+                    print_markdown_table(scored, FRONTIER_FIELDS)
+                finally:
+                    sys.stdout = stdout
+        else:
+            print_markdown_table(scored, FRONTIER_FIELDS)
+
+    return 0
+
+
+def cmd_check_convergence(args: argparse.Namespace) -> int:
+    rows = read_rows(Path(args.input))
+    normalized = []
+    for row in rows:
+        status = str(row.get("status", "")).strip().lower()
+        passed = status in {"pass", "passed", "true", "yes", "y", "1", "ok"}
+        normalized.append(
+            {
+                "check": row.get("check", ""),
+                "status": "pass" if passed else "fail",
+                "evidence": row.get("evidence", ""),
+            }
+        )
+
+    total = len(normalized)
+    passed_count = sum(1 for row in normalized if row["status"] == "pass")
+    failed = [row for row in normalized if row["status"] != "pass"]
+    can_converge = total > 0 and not failed
+
+    result = {
+        "can_converge": can_converge,
+        "passed": passed_count,
+        "total": total,
+        "failed_checks": failed,
+    }
+
+    if args.format == "json":
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print(f"Can converge: {'yes' if can_converge else 'no'}")
+        print(f"Passed: {passed_count}/{total}")
+        if failed:
+            print("\nFailed checks:")
+            print_markdown_table(failed, ["check", "status", "evidence"])
+
+    return 1 if args.strict_exit and not can_converge else 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Domain sensemaking helper.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    init_parser = subparsers.add_parser("init", help="Create a research workspace.")
+    init_parser.add_argument("--output", required=True, help="Output directory.")
+    init_parser.add_argument("--question", default="", help="Initial fuzzy question.")
+    init_parser.add_argument(
+        "--mode",
+        default="Learning",
+        choices=["Learning", "Research / Engineering", "Consulting / Decision"],
+        help="Primary sensemaking mode.",
+    )
+    init_parser.add_argument("--target-output", default="", help="Expected final artifact.")
+    init_parser.add_argument("--force", action="store_true", help="Overwrite existing files.")
+    init_parser.set_defaults(func=cmd_init)
+
+    score_parser = subparsers.add_parser("score-frontier", help="Score and rank frontier rows.")
+    score_parser.add_argument("input", help="CSV or JSON frontier input.")
+    score_parser.add_argument("--output", help="Optional output path.")
+    score_parser.add_argument("--top", type=int, help="Only return the top N rows.")
+    score_parser.add_argument(
+        "--format",
+        choices=["markdown", "csv", "json"],
+        default="markdown",
+        help="Output format.",
+    )
+    score_parser.set_defaults(func=cmd_score_frontier)
+
+    convergence_parser = subparsers.add_parser(
+        "check-convergence", help="Summarize convergence checklist status."
+    )
+    convergence_parser.add_argument("input", help="CSV or JSON convergence checklist.")
+    convergence_parser.add_argument(
+        "--format", choices=["markdown", "json"], default="markdown", help="Output format."
+    )
+    convergence_parser.add_argument(
+        "--strict-exit", action="store_true", help="Exit with code 1 if checks fail."
+    )
+    convergence_parser.set_defaults(func=cmd_check_convergence)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    try:
+        return args.func(args)
+    except Exception as exc:  # noqa: BLE001
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

Add a new **domain-sensemaking** skill for structured research on unfamiliar, ambiguous, or complex domains.

## Files

- `skills/domain-sensemaking/SKILL.md` — 7-step workflow (Frame → Frontier → Explore → Engineer Knowledge → Reframe → Convergence → Synthesize) with 3 modes (Learning, Research/Engineering, Consulting/Decision)
- `skills/domain-sensemaking/scripts/sensemaking_helper.py` — CLI tool with `init`, `score-frontier`, and `check-convergence` commands (Python stdlib only, no external deps)
- `skills/domain-sensemaking/references/templates.md` — Reusable artifact templates for problem cards, frontier queues, node explorations, knowledge tables, convergence checklists, and mode-specific synthesis additions
- `README.md` — Added to Available Skills table

## Testing

Tested with 3 realistic prompts covering all 3 modes:

| Test | Mode | Problem Card | Frontier | Knowledge Tables | Convergence | Final Synthesis |
|---|---|---|---|---|---|---|
| Wasm Component Model | Learning | 5 uncertainties | 8 nodes ranked | 24 relations, 8 claims | 6/6 pass | 172 lines + terminology, learning path, competency questions |
| RAG Long-doc Retrieval | Research/Eng | 6 uncertainties, 4 hypotheses | 8 nodes ranked | 20 relations, 8 claims | 6/6 pass | 141 lines + validation experiment, constraints matrix |
| REST vs gRPC Migration | Consulting | 7 uncertainties | 8 nodes ranked | 18 relations, 8 claims | 6/6 pass | 150 lines + decision statement, scenario analysis, reversal signals |

All 3 helper script commands (`init`, `score-frontier`, `check-convergence`) executed successfully in all tests.