### PR TITLE
[codex] Add domain sensemaking triangulation checks

### DIFF
--- a/skills/domain-sensemaking/SKILL.md
+++ b/skills/domain-sensemaking/SKILL.md
@@ -45,6 +45,8 @@ All paths above are relative to this skill's directory. Resolve them against the
 
 - Treat LLM output as candidate structure or hypotheses, not evidence.
 - Separate `source`, `claim`, `evidence`, and `inference`.
+- Treat repeated search hits, reposts, vendor narratives, and LLM agreement as popularity signals, not independent evidence.
+- For high-impact, controversial, factual, quantitative, or decision-relevant claims, record a triangulation status before assigning high confidence.
 - Preserve question evolution. Do not silently replace the initial question with a cleaner one.
 - Prefer a small explicit knowledge graph over a long reading list.
 - Rank the next frontier before continuing exploration.
@@ -126,6 +128,7 @@ For substantial research, expect at least two rounds unless convergence is obvio
 When you inspect a nontrivial source, create a source note instead of relying on chat memory:
 
 - `source_id`, title, URL/path, source type, access date, and reliability.
+- Upstream origin, source role, and independence note, especially when many sources repeat the same claim.
 - Key points in your own words, preserving enough detail to reuse later.
 - Claims supported or contradicted by the source.
 - Concepts, methods, cases, or examples discovered.
@@ -137,7 +140,7 @@ When you inspect a nontrivial source, create a source note instead of relying on
 Maintain three working tables and **write them to `relations.csv`, `claims.csv`, and `contradictions.csv`** as you go. Update these files incrementally after each exploration round, not just at the end:
 
 - Concept relation table: `A`, `relation`, `B`, `note`.
-- Claim-evidence table: `claim`, `supporting_evidence`, `opposing_evidence`, `confidence`.
+- Claim-evidence table: `claim`, `supporting_evidence`, `opposing_evidence`, `confidence`, `decision_relevance`, `triangulation_status`, `confidence_constraint`.
 - Contradiction/gap table: `type`, `content`, `next_action`.
 
 Use relation labels such as `is-a`, `part-of`, `depends-on`, `causes`, `enables`, `contrasts-with`, `evolves-from`, `used-for`, and `failure-mode-of`.
@@ -165,7 +168,7 @@ Update `convergence.csv` with the current status of each check, then run `check-
 - The question is now specific enough to answer.
 - The main concept/variable/claim graph has no critical isolated nodes.
 - Key disagreements can be explained.
-- Important claims have enough evidence or are explicitly marked uncertain.
+- Important claims have enough independent evidence, direct data, or explicit uncertainty and confidence constraints.
 - A decision, explanation, experiment, or next action can be derived.
 - New exploration mostly repeats known nodes or does not change the conclusion.
 

--- a/skills/domain-sensemaking/references/cognitive-primitives.md
+++ b/skills/domain-sensemaking/references/cognitive-primitives.md
@@ -9,7 +9,7 @@ Use this reference when a research result must become an Agent workflow, evaluat
 | Abduction | The input is vague, surprising, or contradictory | Generate multiple candidate explanations for the observation | hypothesis rows in `frontier.csv` or `claims.csv` |
 | Operationalization | The goal or quality bar is fuzzy | Convert abstract criteria into observable checks, metrics, assertions, or failure thresholds | convergence criteria, evaluation rubric |
 | Hypothetico-deductive loop | A claim needs validation | Turn a hypothesis into predictions, then into evidence-gathering actions | round plan and verification steps |
-| Triangulation | A key claim could be wrong or biased | Check the claim against independent source types, methods, or perspectives | `source-notes/` plus claim evidence |
+| Triangulation | A key claim could be wrong, biased, or popular because many sources repeat it | Trace source origins, compare independent evidence types, look for counterevidence, and assign a triangulation status | `source-notes/` plus `claims.csv` triangulation fields |
 | Bayesian update | Evidence changes confidence but does not decide the issue | Update claim confidence continuously instead of binary pass/fail | confidence field in `claims.csv` |
 | Falsification check | A hard constraint or high-risk assumption exists | Ask what would prove the claim or plan wrong; search for counterevidence | contradiction/gap rows |
 | Metacognitive reflection | Iteration quality matters | Inspect whether the current strategy is producing new signal or just repeating itself | round decision and next frontier |
@@ -31,6 +31,30 @@ For substantial research, use this order:
 9. Skill consolidation: capture reusable lessons only after verification.
 
 Do not load every primitive into every task. Trivial fact lookup needs none. Bounded research usually needs operationalization, one validation loop, and a stop rule. Non-trivial research should use the full composition.
+
+## Triangulation Operation
+
+Triangulation is not "find three sources." It checks whether a claim survives contact with independent evidence. Multiple search results, reposts, vendor summaries, or LLM restatements that trace to the same upstream origin count as one evidence origin.
+
+Use this operation for high-impact, controversial, factual, quantitative, or decision-relevant claims:
+
+1. Identify the exact claim and why it matters to the user's decision or understanding.
+2. Trace upstream origins. Group sources that repeat the same original report, benchmark, paper, vendor post, dataset, or anecdote.
+3. Classify source roles: primary, independent-analysis, replication, aggregator, vendor, opposing, user-provided, or unknown.
+4. Seek at least one opposing or complicating source angle when the claim could materially change the conclusion.
+5. Assign a triangulation status in `claims.csv`.
+
+| Status | Meaning | Confidence Rule |
+|---|---|---|
+| `unverified` | No durable source, or only LLM/search-result snippets. | Low only. |
+| `single-origin` | Support exists, but all support traces to one upstream origin. | Capped at medium. |
+| `corroborated` | Multiple independent origins or evidence types support the claim, and opposition is weak or explained. | May be high. |
+| `contested` | Credible opposing evidence exists. | Capped at medium until resolved or accepted as risk. |
+| `inconclusive` | Evidence is weak, unavailable, capability-limited, or too costly to resolve now. | Low or medium with explicit residual risk. |
+| `direct-data` | Direct experiment, dataset, code inspection, or measurement supports the claim. | May be high if method is adequate. |
+| `not-required` | Low-impact claim where triangulation would not affect the output. | Do not use for high-impact claims. |
+
+High confidence requires `corroborated` or `direct-data`. If the status is `single-origin`, `contested`, or `inconclusive`, write the confidence cap and downstream implication instead of smoothing over the uncertainty.
 
 ## Embedding In Agent Loop
 
@@ -77,7 +101,7 @@ Not every task needs all 8 primitives in the single-task loop:
 | Task complexity | Active primitives | Skippable |
 |---|---|---|
 | Trivial (lookup) | None | All |
-| Bounded (clear scope) | 2, 3, 5, 8 | 1 (already framed), 4 (single source ok), 6 (low risk), 7 (one pass) |
+| Bounded (clear scope) | 2, 3, 5, 8 | 1 (already framed), 4 only for low-impact claims, 6 (low risk), 7 (one pass) |
 | Non-trivial | All 1-8 | None -- but budget each by impact |
 
 ## Mapping To Workspace Files
@@ -87,8 +111,8 @@ Not every task needs all 8 primitives in the single-task loop:
 | `problem-card.md` | abduction seed, operationalized target output |
 | `frontier.csv` | candidate hypotheses, concepts, methods, evidence, and decisions |
 | `rounds/round-XX.md` | hypothetico-deductive loop and metacognitive reflection |
-| `source-notes/source-XXX.md` | triangulation and reusable evidence capture |
-| `claims.csv` | Bayesian confidence and evidence ledger |
+| `source-notes/source-XXX.md` | triangulation, source-origin tracing, and reusable evidence capture |
+| `claims.csv` | Bayesian confidence, triangulation status, and evidence ledger |
 | `contradictions.csv` | falsification checks, gaps, assumptions |
 | `convergence.csv` | satisficing stop and decision readiness |
 | `final-synthesis.md` | reader-calibrated answer, not raw research state |
@@ -101,4 +125,5 @@ Not every task needs all 8 primitives in the single-task loop:
 | Claim pile | Many claims, no reasoning chain | Use final synthesis to connect premise -> evidence -> inference -> answer |
 | False convergence | Checklist says pass but evidence is thin | Run `check-convergence --workspace` and fix lint issues |
 | Unverifiable authority | External papers appear only in final prose | Create `source-notes/` and cite source ids in `claims.csv` |
+| Popularity echo | Many sources repeat the same claim, so confidence rises without source independence | Trace upstream origins and cap status at `single-origin` or `inconclusive` |
 | Over-processing | Simple question gets a full research pipeline | Use triage: skip primitives not needed for the decision |

--- a/skills/domain-sensemaking/references/templates.md
+++ b/skills/domain-sensemaking/references/templates.md
@@ -136,6 +136,9 @@ URL or path:
 Source type: web / paper / report / dataset / interview / internal-doc / observation / other
 Accessed:
 Reliability: high / medium / low
+Upstream origin:
+Source role: primary / independent-analysis / replication / aggregator / vendor / opposing / user-provided / unknown
+Independence note:
 
 ## Why This Source Was Read
 
@@ -207,9 +210,9 @@ Exploration purpose:
 ## Claim-Evidence Table
 
 ```markdown
-| Claim | Supporting evidence | Opposing evidence | Confidence | Decision relevance |
-|---|---|---|---|---|
-|  |  |  | high / medium / low |  |
+| Claim | Supporting evidence | Opposing evidence | Confidence | Decision relevance | Triangulation status | Confidence constraint |
+|---|---|---|---|---|---|---|
+|  |  |  | high / medium / low |  | unverified / single-origin / corroborated / contested / inconclusive / direct-data / not-required |  |
 ```
 
 Confidence guidance:
@@ -217,6 +220,18 @@ Confidence guidance:
 - `high`: multiple reliable sources or direct data support the claim; counterevidence is weak or explained.
 - `medium`: plausible and supported, but limited by source quality, sample size, or unresolved assumptions.
 - `low`: useful hypothesis, but evidence is thin, indirect, outdated, or mostly inferred.
+
+Triangulation guidance:
+
+- `corroborated`: independent origins or evidence types support the claim.
+- `direct-data`: direct experiment, dataset, code inspection, or measurement supports the claim.
+- `single-origin`: many sources repeat one upstream origin; confidence is capped at medium.
+- `contested`: credible opposing evidence exists; confidence is capped at medium until resolved.
+- `inconclusive`: evidence is weak, unavailable, capability-limited, or too costly to resolve now.
+- `unverified`: no durable evidence; keep confidence low.
+- `not-required`: low-impact claim where triangulation would not change the output.
+
+High confidence requires `corroborated` or `direct-data`. Repeated search hits, reposts, vendor narratives, or LLM agreement do not by themselves raise confidence.
 
 ## Coverage Matrix
 
@@ -276,7 +291,7 @@ Before accepting convergence, run the helper with `--workspace` so the checklist
 | Required files | problem card, reader brief, frontier, sources, relations, claims, contradictions, convergence, visual map, final synthesis |
 | Audit trail | `rounds/round-XX.md` exists and records frontier choices |
 | Frontier | rows with scores have computed priority |
-| Claims | evidence, confidence, decision relevance, source ids for high-confidence claims |
+| Claims | evidence, confidence, decision relevance, source ids and triangulation status for high-confidence claims |
 | Sources | external citations in final synthesis have source notes |
 | Final synthesis | required reader-facing sections are present |
 

--- a/skills/domain-sensemaking/scripts/sensemaking_helper.py
+++ b/skills/domain-sensemaking/scripts/sensemaking_helper.py
@@ -36,9 +36,34 @@ SOURCES_FIELDS = [
     "source_type",
     "accessed",
     "reliability",
+    "upstream_origin",
+    "source_role",
+    "independence_note",
     "linked_round",
     "linked_frontier",
 ]
+
+CLAIMS_FIELDS = [
+    "claim",
+    "supporting_evidence",
+    "opposing_evidence",
+    "confidence",
+    "decision_relevance",
+    "triangulation_status",
+    "confidence_constraint",
+]
+
+TRIANGULATION_STATUSES = {
+    "unverified",
+    "single-origin",
+    "corroborated",
+    "contested",
+    "inconclusive",
+    "direct-data",
+    "not-required",
+}
+
+HIGH_CONFIDENCE_TRIANGULATION_STATUSES = {"corroborated", "direct-data"}
 
 REQUIRED_WORKSPACE_FILES = [
     "problem-card.md",
@@ -187,7 +212,7 @@ def cmd_init(args: argparse.Namespace) -> int:
         "frontier.csv": ",".join(FRONTIER_FIELDS) + "\n",
         "sources.csv": ",".join(SOURCES_FIELDS) + "\n",
         "relations.csv": "a,relation,b,note\n",
-        "claims.csv": "claim,supporting_evidence,opposing_evidence,confidence,decision_relevance\n",
+        "claims.csv": ",".join(CLAIMS_FIELDS) + "\n",
         "contradictions.csv": "type,content,likely_cause,next_action,resolution\n",
         "convergence.csv": convergence_csv(),
         "visual-map.md": visual_map(args),
@@ -462,6 +487,9 @@ URL or path: {citation_target}
 Source type: {args.source_type}
 Accessed: {args.accessed}
 Reliability: {args.reliability}
+Upstream origin: {args.upstream_origin}
+Source role: {args.source_role}
+Independence note: {args.independence_note}
 
 ## Why This Source Was Read
 
@@ -499,8 +527,15 @@ Use in synthesis as: {citation}
 def append_source_index(workspace: Path, row: dict[str, Any]) -> None:
     index_path = workspace / "sources.csv"
     exists = index_path.exists()
+    fields = SOURCES_FIELDS
+    if exists:
+        with index_path.open("r", encoding="utf-8-sig", newline="") as handle:
+            reader = csv.reader(handle)
+            existing_header = next(reader, [])
+            if existing_header:
+                fields = existing_header
     with index_path.open("a", encoding="utf-8", newline="") as handle:
-        writer = csv.DictWriter(handle, fieldnames=SOURCES_FIELDS)
+        writer = csv.DictWriter(handle, fieldnames=fields, extrasaction="ignore")
         if not exists:
             writer.writeheader()
         writer.writerow(row)
@@ -527,6 +562,9 @@ def cmd_new_source(args: argparse.Namespace) -> int:
             "source_type": args.source_type,
             "accessed": args.accessed,
             "reliability": args.reliability,
+            "upstream_origin": args.upstream_origin,
+            "source_role": args.source_role,
+            "independence_note": args.independence_note,
             "linked_round": args.linked_round,
             "linked_frontier": args.linked_frontier,
         },
@@ -765,11 +803,43 @@ def lint_workspace(workspace: Path) -> list[dict[str, str]]:
                 )
             confidence = str(row.get("confidence", "")).strip().lower()
             evidence = str(row.get("supporting_evidence", ""))
+            triangulation_status = str(row.get("triangulation_status", "")).strip().lower()
             if confidence == "high" and "source-" not in evidence:
                 issues.append(
                     issue(
                         "high_confidence_claim_without_source_id",
                         "High-confidence claim should cite at least one durable source note id.",
+                        claims_path,
+                        detail=f"row {index}: {row.get('claim', '')}",
+                    )
+                )
+            if triangulation_status and triangulation_status not in TRIANGULATION_STATUSES:
+                issues.append(
+                    issue(
+                        "invalid_triangulation_status",
+                        "Triangulation status is not recognized.",
+                        claims_path,
+                        detail=f"row {index}: {triangulation_status}",
+                    )
+                )
+            if confidence == "high" and is_blank(triangulation_status):
+                issues.append(
+                    issue(
+                        "missing_triangulation_status",
+                        "High-confidence claims need a triangulation status.",
+                        claims_path,
+                        detail=f"row {index}: {row.get('claim', '')}",
+                    )
+                )
+            if (
+                confidence == "high"
+                and triangulation_status
+                and triangulation_status not in HIGH_CONFIDENCE_TRIANGULATION_STATUSES
+            ):
+                issues.append(
+                    issue(
+                        "high_confidence_exceeds_triangulation",
+                        "High confidence requires corroborated or direct-data triangulation.",
                         claims_path,
                         detail=f"row {index}: {row.get('claim', '')}",
                     )
@@ -1169,6 +1239,27 @@ def build_parser() -> argparse.ArgumentParser:
         default="medium",
         choices=["high", "medium", "low"],
         help="Initial reliability assessment.",
+    )
+    source_parser.add_argument("--upstream-origin", default="", help="Original upstream source or origin chain if known.")
+    source_parser.add_argument(
+        "--source-role",
+        default="unknown",
+        choices=[
+            "primary",
+            "independent-analysis",
+            "replication",
+            "aggregator",
+            "vendor",
+            "opposing",
+            "user-provided",
+            "unknown",
+        ],
+        help="Role this source plays in source triangulation.",
+    )
+    source_parser.add_argument(
+        "--independence-note",
+        default="",
+        help="Why this source is independent, dependent, biased, or unclear.",
     )
     source_parser.add_argument("--linked-round", default="", help="Round file or label.")
     source_parser.add_argument("--linked-frontier", default="", help="Frontier node(s) this source informs.")

--- a/skills/domain-sensemaking/scripts/test_sensemaking_helper.py
+++ b/skills/domain-sensemaking/scripts/test_sensemaking_helper.py
@@ -133,6 +133,12 @@ def test_init_creates_workspace() -> None:
         assert (workspace / "visual-map.md").exists()
         assert (workspace / "final-synthesis.md").exists()
         assert (workspace / "rounds/round-01.md").exists()
+        claims_header = (workspace / "claims.csv").read_text(encoding="utf-8").splitlines()[0]
+        assert "triangulation_status" in claims_header
+        assert "confidence_constraint" in claims_header
+        sources_header = (workspace / "sources.csv").read_text(encoding="utf-8").splitlines()[0]
+        assert "upstream_origin" in sources_header
+        assert "source_role" in sources_header
 
 
 def test_lint_workspace_flags_missing_audit_trail() -> None:
@@ -145,7 +151,46 @@ def test_lint_workspace_flags_missing_audit_trail() -> None:
         assert "missing_rounds" in codes
         assert "empty_frontier_priority" in codes
         assert "high_confidence_claim_without_source_id" in codes
+        assert "missing_triangulation_status" in codes
         assert "external_citation_without_source_notes" in codes
+
+
+def test_lint_caps_high_confidence_when_triangulation_is_weak() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = make_bad_workspace(Path(tmp))
+        notes_dir = workspace / "source-notes"
+        notes_dir.mkdir()
+        (notes_dir / "source-001-example.md").write_text("# Source Note source-001\n", encoding="utf-8")
+        write_csv(
+            workspace / "claims.csv",
+            [
+                "claim",
+                "supporting_evidence",
+                "opposing_evidence",
+                "confidence",
+                "decision_relevance",
+                "triangulation_status",
+                "confidence_constraint",
+            ],
+            [
+                {
+                    "claim": "Popular claim repeated by many articles",
+                    "supporting_evidence": "source-001",
+                    "opposing_evidence": "",
+                    "confidence": "high",
+                    "decision_relevance": "Core decision",
+                    "triangulation_status": "single-origin",
+                    "confidence_constraint": "medium max",
+                }
+            ],
+        )
+
+        result = run_helper("lint-workspace", str(workspace), "--format", "json")
+
+        assert result.returncode == 1, result.stdout + result.stderr
+        data = json.loads(result.stdout)
+        codes = {issue["code"] for issue in data["issues"]}
+        assert "high_confidence_exceeds_triangulation" in codes
 
 
 def test_check_convergence_uses_workspace_gate() -> None:
@@ -250,6 +295,9 @@ def test_new_source_creates_note_and_index() -> None:
         assert len(notes) == 1
         note_text = notes[0].read_text(encoding="utf-8")
         assert "Example Paper" in note_text
+        assert "Upstream origin:" in note_text
+        assert "Source role:" in note_text
+        assert "Independence note:" in note_text
         index_text = (workspace / "sources.csv").read_text(encoding="utf-8")
         assert "source-001" in index_text
 
@@ -371,6 +419,7 @@ def main() -> int:
     tests = [
         test_init_creates_workspace,
         test_lint_workspace_flags_missing_audit_trail,
+        test_lint_caps_high_confidence_when_triangulation_is_weak,
         test_check_convergence_uses_workspace_gate,
         test_select_frontier_creates_round_from_top_priority,
         test_new_source_creates_note_and_index,


### PR DESCRIPTION
## Summary

- Operationalize triangulation in domain-sensemaking cognitive primitives with source-origin tracing, source-role classification, confidence statuses, and confidence caps.
- Extend source note and claim evidence templates with upstream origin, source role, independence notes, triangulation status, and confidence constraints.
- Update the helper to generate the new fields and lint high-confidence claims that lack strong triangulation.

## Validation

- git diff --check
- UV_CACHE_DIR=/tmp/uv-cache uv run python skills/domain-sensemaking/scripts/test_sensemaking_helper.py
- UV_CACHE_DIR=/tmp/uv-cache PYTHONPYCACHEPREFIX=/tmp/python-cache uv run python -m py_compile skills/domain-sensemaking/scripts/sensemaking_helper.py skills/domain-sensemaking/scripts/test_sensemaking_helper.py
- bash scripts/validate-skill.sh skills/domain-sensemaking
- deno fmt --check
- deno lint
- deno check scripts/*.ts