### PR TITLE
[codex] Improve surge user-facing output

### DIFF
--- a/skills/surge/SKILL.md
+++ b/skills/surge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: surge
-version: "1.0.3"
+version: "1.0.4"
 description: "Use when a user provides a PRD, spec, or detailed requirements document and needs a full project delivered through iterative expert orchestration — multi-round analyze/research/design/implement/QA cycles with convergence detection. NOT for: single-file edits, quick prototypes, simple Q&A, or tasks without a written spec."
 author: carbonshow
 tags: [orchestration, prd, delivery, multi-agent]
@@ -30,7 +30,7 @@ You are the sole holder of global state, responsible for orchestrating a profess
 - **Research Raw Materials Lost**: Raw web content from WebSearch/WebFetch only exists in the research subagent's context window. Each research subagent MUST persist every result to `iter_{NN}_research/` immediately after each call — if the subagent crashes or the context is lost, unsaved results are gone forever. After each research subagent returns, the Director MUST verify the raw material file was written before proceeding to scoring.
 - **CWD Drift After Subagent**: Subagents may run `cd` commands (e.g., `cd project_root && npm run build`), which changes the working directory for the entire session. After a subagent returns, the Director's relative paths (e.g., `./workspace/tasks/...`) will resolve incorrectly. **Always use absolute paths** for `state.sh` calls and all file I/O. Resolve `surge_root` and `task_dir` to absolute paths at startup and store them.
 - **state.md Field Omission**: When updating state.md, ALWAYS use the `scripts/state.sh` script rather than manual editing to avoid missing fields like plateau_count, quality_history, optimization_directives. The correct argument order is `state.sh <subcommand> <state_file> <field> [value]` (subcommand first, then file). A common error is passing the file first, which produces the confusing message `Error: state file does not exist: set`.
-- **Output Truncation**: After every subagent returns, run Output Integrity Validation (step 5) before Process Output. Never assume output is complete. → `references/output-validation.md`
+- **Output Truncation**: After every subagent returns, run Output Integrity Validation (step 5) before user-facing briefing. Never assume output is complete. → `references/output-validation.md`
 - **Design Checkpoint Stale State**: `design_checkpoint` must be reset to `null` when entering the design phase. → `references/state-schema.md` §design_checkpoint
 - **Epistemic Artifacts Drift**: `epistemic-ledger.md`, `falsification.md`, and `convergence-audit.md` are runtime evidence controls. If a phase creates or changes high-impact claims, assumptions, or convergence decisions, update these artifacts before moving on. Use `scripts/audit-task.js` where available. → `references/epistemic-audit.md`
 
@@ -38,7 +38,8 @@ You are the sole holder of global state, responsible for orchestrating a profess
 
 - **QA Never Converges**: QA tends to give "Pass-Optimizable" rather than "Pass-Converged". If all acceptance criteria have passed and the quality evaluation has no "Insufficient" items, lean towards declaring convergence. **Specific rule**: When ALL quality dimensions are ≥ Good AND all acceptance criteria at the current evaluation level pass, the Director SHOULD declare convergence and enter retro, regardless of the QA's three-value output. → `references/qa-handling.md` §Director Override
 - **Parallel Implement Missing Context**: Each subagent MUST receive `deliverables.md` + its own task package + `context.md`. None can be missing.
-- **Missing Process Output**: After a subagent returns, you MUST show a process summary to the user (key findings, info sources, output paths). Don't just say "done" and skip to the next step—users need to see intermediate content to judge the direction, and need progress indicators to confirm the agent is still working. **This is a mandatory obligation for the Director after every Phase—not optional. Violating this rule is equivalent to a process interruption.**
+- **Missing User-Facing Briefing**: After a phase completes, you MUST show a concise user-facing briefing and update `current-brief.md`. Do not dump raw process logs, trace events, or full phase artifacts into the conversation. Users need the bottom line, evidence basis, risks, decision needed, and next action. → `references/user-facing-output.md`
+- **Decision Log Drift**: Any user decision that changes route, scope, risk acceptance, expert panel, phase skip, acceptance criteria, or convergence MUST be appended to `decision-log.md` before the next phase starts. This file is the durable record of why surge moved in a particular direction.
 - **Research Popularity Bias**: Repeated search hits, LLM agreement, or multiple articles repeating the same upstream source are NOT independent evidence. For high-impact factual, market, scientific, legal, security, or architecture claims discovered in Research, the Director MUST run the Triangulation Gate in `references/phases/research.md` before allowing High confidence or passing the claim into Design as a settled premise.
 - **Quality Oscillation**: If `quality_history` shows the same dimension bouncing back and forth for 3 consecutive rounds (e.g., Basic→Good→Basic), the optimization direction for that dimension has internal conflicts. Do not blindly continue optimizing; lock that dimension or ask the user to rule on priorities.
 - **Optimization Directives Fail**: If the same optimization directive is marked as "Unexecuted" by QA for two consecutive rounds, do not inject it a third time. Explain the situation to the user during the Iteration Review and request guidance.
@@ -119,7 +120,7 @@ bash <repo_root>/scripts/trace.sh <task_dir>/trace.jsonl surge <type> <step> <ro
 | Startup steps 1-5 complete | `step_start` / `step_end` | `startup` | Writing state.md, topology.md, etc. |
 | Before dispatching each subagent | `agent_dispatch` | current phase | Reading phase template + assembling prompt |
 | After subagent returns | `agent_return` | current phase | Output Integrity Validation (step 5) |
-| After validation result | `step_end` | current phase | Process Output (step 6) |
+| After validation result | `step_end` | current phase | User-facing briefing (step 6) |
 | QA conclusion processing | `decision` | `qa` | Updating state.md fields |
 | Convergence check | `checkpoint` | `qa` | Deciding continue/stop |
 | Error/retry | `error` | current phase | Phase Failure Handling |
@@ -150,19 +151,21 @@ The Director should store the returned event ID (printed to stdout by `trace.sh`
 
 Before each major action, the Director MUST print a status line to the user. This provides real-time progress indication during long-running operations and is emitted alongside the trace event.
 
-**Format**: `{emoji} [{step}] {status_description}`
+**Format**: `Status: [{step}] {status_description}`
+
+Status lines are transient progress signals. Do not copy them into durable phase reports or `current-brief.md`.
 
 **Mandatory status announcements:**
 
 | Moment | Status Line |
 |--------|-------------|
-| Before dispatching subagent | `⚡ [analyze] Dispatching subagent — analyzing requirements...` |
-| Subagent returned, validating | `🔍 [analyze] Subagent returned — validating output integrity...` |
-| Validation passed, showing output | `📋 [analyze] Validation passed — processing results...` |
-| QA decision made | `🎯 [qa] Conclusion: Pass-Optimizable — evaluating convergence...` |
-| Starting new iteration | `🔄 [iter 2] Starting iteration 2 (full cycle)...` |
-| Convergence detected | `✅ [convergence] All criteria met — preparing completion review...` |
-| Error/retry | `⚠️ [implement] SEVERE_TRUNCATION detected — retrying with scope reduction...` |
+| Before dispatching subagent | `Status: [analyze] Dispatching subagent to analyze requirements.` |
+| Subagent returned, validating | `Status: [analyze] Subagent returned; validating output integrity.` |
+| Validation passed, showing output | `Status: [analyze] Validation passed; preparing user briefing.` |
+| QA decision made | `Status: [qa] Conclusion is Pass-Optimizable; evaluating convergence.` |
+| Starting new iteration | `Status: [iter 2] Starting iteration 2 as a full cycle.` |
+| Convergence detected | `Status: [convergence] Criteria met; preparing completion review.` |
+| Error/retry | `Status: [implement] Severe truncation detected; retrying with scope reduction.` |
 
 **Rules Loading**: After Startup completes and before entering the Main Iteration Loop, the Director MUST read `{surge_root}/rules.md` into active context. This file contains NEVER/ALWAYS/PREFER constraints that act as guardrails throughout execution. If the file does not exist (e.g., `init.sh` was skipped), copy from `assets/rules.md` first.
 
@@ -187,8 +190,8 @@ Each iteration executes 5 Phases sequentially. The QA conclusion dictates whethe
 4. **[MANDATORY] Emit trace event**: `bash <repo_root>/scripts/trace.sh "$TRACE_FILE" surge agent_dispatch {phase} "$ROUND" subagent:{phase} '{...}'` — store the returned event ID.
 5. Dispatch the subagent via the Agent tool.
 6. **[MANDATORY] Emit trace event**: `bash <repo_root>/scripts/trace.sh "$TRACE_FILE" surge agent_return {phase} "$ROUND" subagent:{phase} '{...}'` — include `parent_id` from step 4 and `validation_result`.
-7. **[MANDATORY] Output Integrity Validation**: Read the expected output file(s) and validate against the phase's required-section checklist in `references/output-validation.md`. Classify as PASS / MINOR_TRUNCATION / SEVERE_TRUNCATION. If not PASS, execute the corresponding recovery strategy (see `references/output-validation.md`) before proceeding. Do NOT skip to Process Output on a non-PASS result. **For multi-output phases (design, research)**: validate each output file independently; for research, raw materials are validated incrementally during the Director loop — only the summary document goes through post-phase validation.
-8. **[MANDATORY] After validation passes, show a process summary to the user** (see "Process Output" below). **Do NOT proceed to the next Phase without showing a progress summary.**
+7. **[MANDATORY] Output Integrity Validation**: Read the expected output file(s) and validate against the phase's required-section checklist in `references/output-validation.md`. Classify as PASS / MINOR_TRUNCATION / SEVERE_TRUNCATION. If not PASS, execute the corresponding recovery strategy (see `references/output-validation.md`) before proceeding. Do NOT skip to the user-facing briefing on a non-PASS result. **For multi-output phases (design, research)**: validate each output file independently; for research, raw materials are validated incrementally during the Director loop — only the summary document goes through post-phase validation.
+8. **[MANDATORY] After validation passes, show a user-facing phase briefing** (see "Process Output" below). **Do NOT proceed to the next Phase without updating `current-brief.md` and showing the briefing.**
 
 > The files under `references/phases/` are prompt templates. They should be read via the Read tool and injected into the subagent prompt, **NOT invoked via the Skill tool**.
 
@@ -196,7 +199,7 @@ Each iteration executes 5 Phases sequentially. The QA conclusion dictates whethe
 After the Analyze subagent returns and output is validated, the Director MUST check the "Ambiguities & Questions to Clarify" section:
 1. **If any ambiguity has impact scope covering P0 requirements or ≥3 phases**: Present ALL such ambiguities to the user via AskUserQuestion, including the analyze agent's suggested clarification method. Wait for user response.
 2. **Inject user answers**: Write confirmed answers into `context.md` (append as "## User Clarifications" section), so all downstream phases reference them.
-3. **If ALL ambiguities are minor** (impact limited to a single non-critical module): The Director may proceed with stated assumptions, but MUST list those assumptions in the process summary shown to the user and get acknowledgment.
+3. **If ALL ambiguities are minor** (impact limited to a single non-critical module): The Director may proceed with stated assumptions, but MUST list those assumptions in the user-facing briefing and get acknowledgment.
 4. **If no ambiguities**: Proceed normally.
 
 This gate applies to EVERY iteration's analyze phase, not just the first round.
@@ -219,9 +222,9 @@ If obvious dead links or naming conflicts are found, dispatch an agent to fix th
 
 ### Process Output
 
-> Complete per-phase content requirements, format examples, and subagent prompt cooperation instructions are in `references/process-output.md`.
+> Complete per-phase briefing requirements, format examples, and subagent prompt cooperation instructions are in `references/process-output.md`. The user-facing briefing contract is in `references/user-facing-output.md`.
 
-After each subagent returns, the Director **MUST** present a brief process summary to the user (key findings, info sources, output paths). This is mandatory — not optional. If the subagent's response omits the summary, the Director extracts key information from the output files directly.
+After each phase completes, the Director **MUST** present a concise user-facing briefing and update `current-brief.md`. This is mandatory — not optional. If the subagent's response omits the needed information, the Director extracts the bottom line, evidence basis, risks, decision need, and next action from the output files directly. Append route-changing user decisions to `decision-log.md`.
 
 ### Token Budget Guidelines
 
@@ -308,7 +311,8 @@ After retro finishes:
 | `references/qa-handling.md` | QA 3-value logic, convergence, Director Override, deviations, test evolution, lightweight paths, directive verification | After QA results |
 | `references/state-schema.md` | state.md field definitions and update rules | When updating state |
 | `references/output-structure.md` | Directory structure, file naming rules | When confirming paths |
-| `references/process-output.md` | Per-phase process summary requirements, format examples, subagent cooperation instructions | After every subagent return (step 6) |
+| `references/process-output.md` | Per-phase briefing requirements, format examples, subagent cooperation instructions | After every phase validation (step 6) |
+| `references/user-facing-output.md` | Briefing layer, symbol policy, `current-brief.md`, and `decision-log.md` rules | Before showing progress or decisions to the user |
 | `references/token-budget.md` | Context window management rules, estimation heuristics | When assembling subagent prompts (especially iteration ≥ 3) |
 | `references/epistemic-audit.md` | Ledger, source triangulation, falsification, convergence, and Goodhart audit protocol | When claims, evidence, or convergence decisions matter |
 | `references/platform-adapter.md` | Claude/Cursor/Gemini capability mapping and fallbacks | Startup and any platform-specific execution uncertainty |

--- a/skills/surge/references/output-structure.md
+++ b/skills/surge/references/output-structure.md
@@ -26,6 +26,8 @@ This document defines the directory structure and file naming conventions for su
 ├── deliverables.md         ← Deliverables negotiation result (Step 4)
 ├── acceptance.md           ← Tiered acceptance criteria (Step 5)
 ├── test_cases.md           ← Independently accumulated evolving test suite
+├── current-brief.md        ← User-facing resumable briefing, overwritten after each phase
+├── decision-log.md         ← Append-only user decision and override record
 ├── memory_draft.md         ← Process experience records (append mode)
 ├── epistemic-ledger.md     ← Hypotheses, claims, evidence, confidence, decision impact
 ├── falsification.md        ← High-risk disconfirmation checks
@@ -164,6 +166,8 @@ importance: 5
 | implement (parallel sub) | `iter_{NN}_implement_{module}.md` | Independent report for each parallel module |
 | qa | `iter_{NN}_qa.md` | QA acceptance report, incl. three-value conclusion |
 | retro | `retro.md` | Retro report (not in iterations/, directly in task root) |
+| current brief | `current-brief.md` | User-facing latest task state and next action; overwritten after startup and each phase |
+| decision log | `decision-log.md` | Append-only user decisions, skipped phases, overrides, veto acknowledgements, and acceptance criteria changes |
 | trace | `trace.jsonl` | Execution trace events in JSONL format (append-only, see `docs/TRACE_SPEC.md`) |
 | trace export | `execution_dag.mmd` | Mermaid DAG visualization (generated post-retro by `scripts/trace-export.sh`) |
 | trace export | `execution_summary.md` | Markdown execution summary table (generated post-retro by `scripts/trace-export.sh`) |

--- a/skills/surge/references/output-validation.md
+++ b/skills/surge/references/output-validation.md
@@ -1,6 +1,6 @@
 # Output Validation & Recovery Reference
 
-After every subagent returns, the Director reads this document to validate output integrity before proceeding to Process Output or the next phase.
+After every subagent returns, the Director reads this document to validate output integrity before proceeding to the user-facing briefing or the next phase.
 
 ---
 
@@ -14,8 +14,10 @@ Perform these checks on every subagent output, regardless of phase.
 | S2 | **Non-empty** | Verify meaningful content beyond title/frontmatter | < 10 lines of actual content |
 | S3 | **No abrupt ending** | Inspect last ~20 lines for completeness | Last line is an incomplete sentence, an unclosed ``` block, or an unfinished list item |
 | S4 | **No stall pattern** | Check that output contains task-specific analysis, not just role preamble or repeated boilerplate | Content is >80% template/boilerplate with no substantive analysis |
+| S5 | **Reader Summary for canonical phase reports** | For analyze/research summary/design/implement/qa/retro outputs, inspect the top ~40 lines for `Reader Summary` or an equivalent bottom-line summary. Raw research materials and individual expert reviews are exempt. | Missing summary is a readability defect; prepend a concise summary before using the file downstream |
 
 S1–S3 are **hard signals** (high confidence of truncation). S4 is a **soft signal** (suggestive, not conclusive).
+S5 is a **readability signal**: it does not prove truncation, but it blocks user-facing handoff until repaired.
 
 ---
 
@@ -217,8 +219,8 @@ If splitting also fails, proceed to User Escalation (§D).
 Present the situation to the user with clear options:
 
 ```
-⚠️ [{phase}] Output Validation Failed — Escalation Required
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+[{phase}] Output Validation Failed - Escalation Required
+
 Attempts made:
   1. {First attempt type}: {result}
   2. {Second attempt type}: {result}

--- a/skills/surge/references/phases/analyze.md
+++ b/skills/surge/references/phases/analyze.md
@@ -19,7 +19,9 @@ The Director will provide the following file contents in the prompt:
 
 1. Carefully read the PRD to understand the core objectives and constraints.
 
-2. Output an analysis document, which must include the following sections (format as you see fit):
+2. Output an analysis document. Start with `## Reader Summary`, then include the detailed sections below (format the details as you see fit):
+
+   - **Reader Summary**: Bottom-line interpretation of the PRD, the main evidence basis, material risks, whether user clarification is required, and the next action.
 
    - **Functional Requirements List**: Each requirement should include priority (P0/P1/P2) and PRD source citation.
    - **Problem Reframe & Initial Hypotheses**: State the current interpretation of the task, 3-7 material hypotheses or assumptions, and what observable would change each one.

--- a/skills/surge/references/phases/design.md
+++ b/skills/surge/references/phases/design.md
@@ -130,6 +130,7 @@ Produce detailed design for the **selected solution**, incorporating all accepte
 The Director may delegate this to a design subagent for complex domains.
 
 **Output sections** (included in `iter_{NN}_design.md`):
+- **Reader Summary**: Selected solution, evidence basis, accepted risks, user decision status, and next implementation action.
 - **Selected Solution & Reasons**: Which solution was chosen and why
 - **Assumptions, Predictions, and Invalidation Conditions**: Important claims that must be recorded in `epistemic-ledger.md`, plus any falsification checks required before convergence.
 - **Detailed Design**:
@@ -140,7 +141,7 @@ The Director may delegate this to a design subagent for complex domains.
 
 ### Step 7: Design Confirmation [Checkpoint 4]
 
-Present the full design summary to the user. Highlight any points where the design **diverges** from expert recommendations (with rationale).
+Present a user-facing design briefing, not the full design document inline. The briefing must state the selected solution, why alternatives lost, accepted expert constraints, material risks, and any points where the design **diverges** from expert recommendations (with rationale). Link to `iter_{NN}_design.md` for details.
 
 **User options**:
 - **A) Approve** — design is finalized
@@ -148,7 +149,7 @@ Present the full design summary to the user. Highlight any points where the desi
 
 **State update**: `design_checkpoint` ← `"design_confirmed"`
 
-> **NOTE**: This checkpoint serves as the process summary. There is no separate post-phase summary step.
+> **NOTE**: This checkpoint serves as the phase briefing. There is no separate post-phase briefing step.
 
 ### Step 8: Parallelizable Module Identification
 

--- a/skills/surge/references/phases/implement.md
+++ b/skills/surge/references/phases/implement.md
@@ -101,6 +101,7 @@ Common sources of findings:
 
 The output document must include the following sections (format as you see fit):
 
+- **Reader Summary**: What was produced, evidence or verification basis, material limitations, whether user or Director action is needed, and next action.
 - **Implementation Overview**: Briefly describe what was implemented and what method was adopted.
 - **Output Mode Declaration**: Actual Files / Document
 - **File List** (Actual File Mode): Path, functional description, and status of each file.

--- a/skills/surge/references/phases/qa.md
+++ b/skills/surge/references/phases/qa.md
@@ -169,6 +169,7 @@ If the directive comes with an intensity label (like `[REFINEMENT-ONLY]` or `[RE
 
 Write the acceptance results into the output document, which must include the following sections (format as you see fit):
 
+- **Reader Summary**: Delivery verdict first, then blocker vs non-blocking issues, evidence basis, residual risk, and next action.
 - **Acceptance Conclusion**: Three-value judgment (Fail / Pass-Optimizable / Pass-Converged), including Pass/Partial Pass/Fail item counts and evaluation level.
 - **Details of Pass/Partial Pass/Fail Items**: Each containing acceptance criteria, verification result or failure reason; Partial Pass and Fail items MUST include deviation level.
 - **Overall Deviation Level**: Take the highest level and explain the reason (if all pass, state no deviation).

--- a/skills/surge/references/phases/research.md
+++ b/skills/surge/references/phases/research.md
@@ -133,15 +133,20 @@ For mandatory or deep research, extend the scoring notes with:
 
 **Present to user**:
 
-```
-Research Tree — Layer {Depth}
----
+Use a pruning briefing, not a raw process dump. Keep numeric scoring in the
+Director's notes and raw material frontmatter. The user-facing table should
+show priority and evidence state in plain language.
 
-| # | Direction | Relevance | Importance | Reason |
-|---|-----------|-----------|------------|--------|
-| 1 | ... | *****  | ****  | [1-sentence explanation] |
-| 2 | ... | ***  | ***** | ... |
-| 3 | ... | **  | **  | ... |
+```
+## Bottom Line
+
+[One sentence explaining what this layer has clarified.]
+
+| # | Direction | Priority | Evidence State | Recommendation | Why |
+|---|---|---|---|---|---|
+| 1 | ... | High | Corroborated | Deepen | [1-sentence explanation] |
+| 2 | ... | Medium | Single-source | Stop unless needed | ... |
+| 3 | ... | Low | Inconclusive | Prune | ... |
 
 Parent Direction: {Name of current expanding parent node, Root shows "---"}
 Completed Depth: {Current Layer}/{Max Explored Depth}
@@ -152,7 +157,7 @@ Completed Depth: {Current Layer}/{Max Explored Depth}
 The Director presents the following options to the user (via direct message, NOT via subagent):
 
 > Please select the directions to research deeper, or:
-> - **A) Check numbers**: Enter the direction numbers to deepen (e.g., `1,3`)
+> - **A) Choose directions**: Enter the direction numbers to deepen (e.g., `1,3`)
 > - **B) Continue all**: Deepen research into all directions
 > - **C) All sufficient, next phase**: End research, summarize existing results
 > - **D) Add direction**: Add a new research direction not in the table
@@ -166,7 +171,7 @@ The Director presents the following options to the user (via direct message, NOT
 When auto-skipping, notify the user:
 
 ```
-[Auto-Continue] Direction "{Direction Name}" has only {N} high-scoring sub-directions, automatically deepening research.
+Auto-continue: Direction "{Direction Name}" has only {N} high-priority sub-directions, so research will deepen without asking for another pruning decision.
 ```
 
 **If the above conditions are not met, the Director MUST wait for user confirmation.**
@@ -228,6 +233,8 @@ Write a structured summary to: {task_dir}/iterations/iter_{NN}_research.md
 
 The summary MUST include the following sections:
 
+- **Reader Summary**: Bottom line, evidence basis, material risks or unresolved evidence gaps, decision or next action.
+
 - **Research Conclusion Summary**: 2-3 sentences summarizing core findings.
 
 - **Research Tree Overview**: The complete research tree structure, marking the status of each node (researched/pruned by user/auto-skipped, etc.).
@@ -253,12 +260,13 @@ The summary MUST include the following sections:
 - **User Decision Records**: Pruning decisions made during research.
 
 ## Process Output Requirement
-In your final reply (not the content written to the file), please provide an additional brief process summary containing:
-- Key findings or decisions of this phase (3-5 items, one sentence each)
-- External info sources used (URLs, lit IDs, etc., if any)
+In your final reply (not the content written to the file), please provide the information the Director needs for a user-facing briefing:
+- Bottom line of this phase (1-2 sentences)
+- Evidence basis: key external info sources used (URLs, lit IDs, etc., if any)
 - Triangulation status for high-impact claims, including unresolved `Single-source`, `Contested`, or `Inconclusive` items
+- Material risks or uncertainties that affect design
+- Whether a user decision is needed
 - Output file path and approximate line count
-- Unexpected situations or issues needing Director's attention (skip if none)
 ```
 
 After the summary subagent returns, the Director validates the output per `references/output-validation.md` (research phase checklist).

--- a/skills/surge/references/phases/retro.md
+++ b/skills/surge/references/phases/retro.md
@@ -36,6 +36,7 @@ Read through the entire Context Package to understand the complete execution tra
 
 Write to `{surge_root}/tasks/{task_id}/retro.md`, which must include the following sections (format as you see fit):
 
+- **Reader Summary**: What was delivered, convergence basis, residual risks, and recommended follow-up.
 - **Basic Task Info**: Task ID, completion time, final status (completed / terminated early / partially completed).
 - **Goal Achievement**: Compared to the original requirement, explain what was achieved, what was not, and why.
 - **Execution Trajectory**: Number of iterations, phases completed per round, deviations, and main issues.

--- a/skills/surge/references/process-output.md
+++ b/skills/surge/references/process-output.md
@@ -1,18 +1,20 @@
 # Process Output Reference
 
-**Purpose**: (1) Let the user see key contents of the intermediate process to judge if the direction is right; (2) Provide a progress indicator during long runs so the user doesn't think the task is stuck.
+**Purpose**: Show users the current conclusion, evidence basis, risks, decision needs, and next action without forcing them to read raw process logs.
 
 ---
 
 ## Director's Duty
 
-After each subagent returns, the Director MUST present a brief process summary to the user. **This is a mandatory obligation after every Phase — not optional. Violating this rule is equivalent to a process interruption.**
+After each phase completes, the Director MUST present a user-facing briefing and update `current-brief.md`. **This is a mandatory obligation after every Phase — not optional. Violating this rule is equivalent to a process interruption.**
+
+Use `references/user-facing-output.md` as the source of truth for briefing structure, symbol policy, and `decision-log.md` updates.
 
 ### Pre-Phase Status Announcement
 
 Before dispatching each subagent, the Director MUST also print a status line to provide real-time progress indication:
 
-**Format**: `{emoji} [{step}] {status_description}`
+**Format**: `Status: [{step}] {status_description}`
 
 This is a one-line announcement before the action, NOT a summary after the action. It serves as a real-time heartbeat so the user knows the task is progressing. The status line is also emitted as a trace event (see Execution Trace Protocol in `SKILL.md`).
 
@@ -20,13 +22,13 @@ This is a one-line announcement before the action, NOT a summary after the actio
 
 ## Required Content Per Phase
 
-| Phase | Required Process Content |
+| Phase | Required Briefing Content |
 |-------|--------------------------|
-| analyze | Number of key requirements, ambiguities, and high-risk items identified (list IDs and 1-sentence descriptions). |
-| research | **Key findings from web search/fetch** (source URLs, core conclusions), pruning decisions at each layer, **triangulation status for high-impact claims**, and **number of raw material files saved** (with directory path). Note: because research is Director-orchestrated with per-layer user interaction, progress is shown incrementally during the phase — the post-phase summary covers the final summary document only. |
-| design | Checkpoint 4 (Design Confirmation) serves as the process summary. No separate post-phase summary needed — the 4 checkpoints provide transparency throughout the phase. |
-| implement | Module name completed by each subagent, output file paths, lines of code, **edge cases discovered** (if any). |
-| qa | Number of Passed/Partial/Failed items, quality score changes, P0 issue list. |
+| analyze | Bottom-line interpretation, decision-blocking ambiguities, high-risk items, and whether user clarification is required. |
+| research | Evidence-backed conclusions, source independence or triangulation status, unresolved factual gaps, and pruning decisions that affect design. |
+| design | Selected option, why alternatives lost, accepted expert constraints or veto overrides, and the user approval point. |
+| implement | Actual files or document sections produced, verification performed, discovered edge cases, and any design mismatch. |
+| qa | Delivery verdict, blocker vs non-blocking issues, quality movement, residual risk, and next iteration or convergence decision. |
 
 ---
 
@@ -35,18 +37,33 @@ This is a one-line announcement before the action, NOT a summary after the actio
 Director showing to user:
 
 ```
-📋 [research] Subagent finished — Key Findings:
-  • Approach A focuses on runtime adaptation, differs from our static-analysis path — no overlap.
-  • arXiv:2507.18224 uses a learning-driven path, different from our formalization path.
-  • CrewAI/AutoGen/LangGraph have no auto-topology generation (blank space confirmed).
-  → Output: iter_01_research.md (xxx lines)
+## Bottom Line
+
+Research supports the static-analysis path. The runtime-adaptation alternatives do not solve the core requirement.
+
+## Basis
+
+- `iter_01_research.md` maps the relevant sources to the candidate comparison.
+- Two independent source groups support the same design constraint; no material counter-evidence was found.
+
+## Risks and Uncertainties
+
+- Benchmark claims remain single-source, so design should not rely on exact throughput numbers.
+
+## Decision Needed
+
+No user decision needed.
+
+## Next Action
+
+Proceed to design with the static-analysis path as the leading candidate.
 ```
 
 ---
 
 ## Director Self-Check
 
-If the subagent's response does not include a progress summary (the subagent may have ignored the Process Output Requirement), the Director MUST extract key information from the subagent's output files and present it to the user, rather than skipping the summary.
+If the subagent's response does not include the information needed for a briefing, the Director MUST extract key information from the output files and present it to the user, rather than skipping the briefing.
 
 ---
 
@@ -56,11 +73,12 @@ When the Director concatenates the subagent prompt, it MUST append the following
 
 ```
 ## Process Output Requirement
-In your final reply (not the content written to the file), please provide an additional brief process summary containing:
-- Key findings or decisions of this phase (3-5 items, one sentence each)
-- External info sources used (URLs, lit IDs, etc., if any)
+In your final reply (not the content written to the file), please provide the information the Director needs for a user-facing briefing:
+- Bottom line of this phase (1-2 sentences)
+- Evidence basis (important sources, files, tests, or expert judgments)
+- Material risks or uncertainties that affect downstream decisions
+- Whether a user decision is needed
 - Output file path and approximate line count
-- Unexpected situations or issues needing Director's attention (skip if none)
 ```
 
 
@@ -71,3 +89,5 @@ The Director and all subagents MUST prioritize human readability and logical flo
 - **Logical Deductive Flow**: Structure conclusions as a logical argument (Observation -> Hypothesis -> Evidence -> Conclusion), rather than just abruptly stating the final result.
 - **Synthesis over Summarization**: When processing upstream documents, synthesize the core insights into a cohesive viewpoint rather than mechanically summarizing each source.
 - **Calibrated Tone**: The tone should be professional yet conversational (like a senior consultant briefing a stakeholder), avoiding robotic, overly formulaic, or strictly templated stiffness.
+- **Reader Summary First**: Canonical phase reports start with `## Reader Summary` before detailed process sections. Raw research materials and individual expert reviews are exempt.
+- **Plain Symbols**: Avoid emoji, decorative dividers, star ratings, and dense status markers in durable Markdown. Keep machine-readable markers inside evidence files and translate them in user-facing briefings.

--- a/skills/surge/references/qa-handling.md
+++ b/skills/surge/references/qa-handling.md
@@ -236,7 +236,7 @@ Historical Output Files (Available for review):
 - If no calibration concerns: Proceed to Completion Review Checkpoint normally.
 - If calibration concerns found: Add `[CALIBRATION WARNING]` tags to the Completion Review display:
   ```
-  ⚠️ Calibration Warnings:
+  Calibration Warnings:
   - [CALIBRATION WARNING: QA may be too lenient — dismissed 4 identified issues as "acceptable"]
   - [CALIBRATION WARNING: Robustness jumped Basic→Excellent in one round without major implementation changes]
   ```

--- a/skills/surge/references/startup.md
+++ b/skills/surge/references/startup.md
@@ -51,6 +51,8 @@ The initialization script will automatically generate the directory structure an
 ├── context.md          ← Manually write PRD + background knowledge to this file
 ├── state.md            ← Initial state (see schema below)
 ├── test_cases.md       ← QA evolving test suite
+├── current-brief.md    ← User-facing latest task state and next action
+├── decision-log.md     ← Append-only user decisions and overrides
 ├── epistemic-ledger.md ← Hypotheses, claims, evidence, confidence
 ├── falsification.md    ← High-risk disconfirmation checks
 ├── convergence-audit.md← Evidence behind stop/convergence decisions
@@ -59,6 +61,10 @@ The initialization script will automatically generate the directory structure an
 ```
 
 Then, write the PRD and background knowledge provided by the user into `{surge_root}/tasks/{task_id}/context.md`.
+
+Update `current-brief.md` after the startup negotiation completes. Append to
+`decision-log.md` whenever the user confirms task topology, deliverable paths,
+acceptance criteria, phase skips, expert veto overrides, or convergence choices.
 
 > ⚠️ **Path Resolution**: After determining `surge_root` and `task_id`, the Director MUST resolve the task directory to an **absolute path** and use it for ALL subsequent file operations (state.sh calls, file reads/writes, subagent prompts). Subagent execution (especially `npm run build`, `cd` commands) can change the working directory, causing relative paths to break silently.
 >
@@ -451,4 +457,4 @@ Options:
 
 ### Post-Resume
 
-After the user confirms, the Director enters the Main Iteration Loop at the determined phase. All normal rules apply (Phase Invocation Flow, Output Validation, Process Output, etc.).
+After the user confirms, the Director enters the Main Iteration Loop at the determined phase. All normal rules apply (Phase Invocation Flow, Output Validation, user-facing briefing, etc.).

--- a/skills/surge/references/user-facing-output.md
+++ b/skills/surge/references/user-facing-output.md
@@ -1,0 +1,123 @@
+# User-Facing Output Layer
+
+This reference defines what the Director shows to the user while surge runs.
+It separates human-readable briefings from runtime evidence files.
+
+## Purpose
+
+surge produces many artifacts because it is an execution and audit system:
+`trace.jsonl`, `state.md`, phase reports, expert reviews, raw research files,
+epistemic ledgers, and convergence audits. Those files are useful for control
+and replay, but they are not the default reading surface for the user.
+
+The default user surface is a briefing: conclusion first, evidence second,
+risks third, decision request last.
+
+## Output Separation
+
+Use three layers:
+
+| Layer | Audience | Examples | User-facing by default |
+|---|---|---|---|
+| Runtime control | Director and scripts | `state.md`, `trace.jsonl`, `platform-capabilities.md` | No |
+| Evidence archive | Audit and recovery | `iterations/*`, raw research files, ledgers, QA details | No |
+| Briefing layer | User and decision maker | phase briefings, `current-brief.md`, `decision-log.md`, completion review | Yes |
+
+The Director may link to evidence files, but should not make the user read
+the evidence archive to understand the current state.
+
+## Durable Briefing Files
+
+The Context Package contains two user-readable files:
+
+- `current-brief.md`: overwritten after startup and after every phase. It is the
+  best single file to open when resuming a task.
+- `decision-log.md`: append-only record of user decisions, skipped phases,
+  overrides, veto acknowledgements, and acceptance criteria changes.
+
+Do not duplicate full phase reports in these files. Link to the relevant files.
+
+## Default Phase Briefing
+
+After a phase completes, the Director updates `current-brief.md` and shows a
+short briefing to the user using this structure:
+
+```markdown
+## Bottom Line
+
+[One or two sentences stating what changed and what it means.]
+
+## Basis
+
+- [Evidence item or output file that supports the conclusion.]
+- [Important source, test result, expert consensus, or QA finding.]
+
+## Risks and Uncertainties
+
+- [Only include risks that can affect downstream decisions.]
+
+## Decision Needed
+
+[No user decision needed / one concrete question with options.]
+
+## Next Action
+
+[The next phase or recovery action.]
+```
+
+Rules:
+
+- Lead with the result, not with the steps taken.
+- Keep the briefing short enough to read in under one minute.
+- Prefer narrative synthesis over a list of every artifact produced.
+- If the user must decide, ask one decision question and list the impact of
+  each option.
+- If no decision is needed, say so explicitly.
+
+## Symbol Policy
+
+Keep symbols out of the user's main reading path.
+
+- Real-time status lines may use host-specific styling, but durable Markdown
+  should use plain text.
+- Prefer `Status: [phase] ...` for progress messages.
+- Do not use emoji, decorative dividers, star ratings, or dense marker sets in
+  durable briefings.
+- Keep machine-readable markers such as `[BLOCKED]`, `[VETOED]`,
+  `[DEGRADED]`, `[ASSUMPTION]`, and `[DESIGN_MISMATCH]` inside evidence files.
+  Translate them in user-facing briefings.
+
+Example translation:
+
+| Evidence marker | User-facing wording |
+|---|---|
+| `[DEGRADED: helm unavailable]` | "Helm validation could not be run because the tool is unavailable." |
+| `[VETOED by Security Expert]` | "The security reviewer rejected this option because ..." |
+| `[BLOCKED: missing source]` | "This cannot proceed until the missing source is provided." |
+
+## Phase-Specific Briefing Focus
+
+| Phase | User-facing focus |
+|---|---|
+| analyze | Requirement interpretation, contradictions, decision-blocking ambiguities, high-impact risks |
+| research | Evidence-backed conclusions, independent source status, unresolved factual gaps |
+| design | Selected option, why rejected alternatives lost, accepted risks, user approval point |
+| implement | Actual changes or produced deliverables, verification performed, discovered edge cases |
+| qa | Delivery verdict, blockers vs non-blocking improvements, residual risk, next iteration decision |
+| retro | What was delivered, what was learned, what should change in future runs |
+
+## Reader Summary Requirement
+
+Canonical phase reports must start with `## Reader Summary` before detailed
+phase sections. Expert review files and raw research material files are exempt
+because they are evidence artifacts.
+
+The summary must contain:
+
+- Bottom line
+- Evidence basis
+- Decision or next action
+- Material risks, if any
+
+If a canonical phase report lacks this summary, the Director should treat it as
+a readability defect and prepend a concise summary before using it downstream.

--- a/skills/surge/scripts/init.sh
+++ b/skills/surge/scripts/init.sh
@@ -133,6 +133,50 @@ else
     echo "  - memory_draft.md already exists, skipping"
 fi
 
+# Create user-facing briefing artifacts (skip if exists)
+if [[ ! -f "${TASK_DIR}/current-brief.md" ]]; then
+    cat > "${TASK_DIR}/current-brief.md" << 'EOF'
+# Current Brief
+
+## Bottom Line
+
+Context package initialized. The Director should update this file after startup and after every phase.
+
+## Basis
+
+- The task directory and runtime control files have been created.
+
+## Risks and Uncertainties
+
+- None recorded yet.
+
+## Decision Needed
+
+Startup negotiation is still pending.
+
+## Next Action
+
+Confirm task topology, deliverables, and acceptance criteria.
+EOF
+    echo "  ✓ Created current-brief.md"
+else
+    echo "  - current-brief.md already exists, skipping"
+fi
+
+if [[ ! -f "${TASK_DIR}/decision-log.md" ]]; then
+    cat > "${TASK_DIR}/decision-log.md" << 'EOF'
+# Decision Log
+
+Append user decisions, skipped phases, overrides, veto acknowledgements, and acceptance criteria changes.
+
+| Time | Phase | Decision | Options Considered | Rationale | Impact |
+|---|---|---|---|---|---|
+EOF
+    echo "  ✓ Created decision-log.md"
+else
+    echo "  - decision-log.md already exists, skipping"
+fi
+
 # Create empty trace.jsonl for execution tracing (skip if exists)
 if [[ ! -f "${TASK_DIR}/trace.jsonl" ]]; then
     touch "${TASK_DIR}/trace.jsonl"
@@ -229,6 +273,8 @@ echo "    └── ${TASK_ID}/"
 echo "        ├── state.md"
 echo "        ├── context.md"
 echo "        ├── memory_draft.md"
+echo "        ├── current-brief.md"
+echo "        ├── decision-log.md"
 echo "        ├── trace.jsonl"
 echo "        ├── test_cases.md"
 echo "        ├── epistemic-ledger.md"


### PR DESCRIPTION
## Summary

- Add a user-facing output layer for surge that separates runtime control, evidence archives, and user briefings.
- Require `current-brief.md`, `decision-log.md`, and `Reader Summary` sections for clearer resumability and decision handoff.
- Update phase templates, output validation, startup docs, and init scaffolding to reduce process-log noise and symbol-heavy durable output.
- Bump surge, repo, Claude plugin, Cursor plugin, Claude marketplace, and Gemini extension versions to `1.0.4`, with a changelog entry.

## Validation

- `deno fmt --check`
- `deno lint`
- `deno check scripts/*.ts`
- `bash scripts/validate-skill.sh skills/surge`
- `bash -n skills/surge/scripts/init.sh`
- init smoke test for `current-brief.md`, `decision-log.md`, and `trace.jsonl`
- `python3 -m json.tool .claude-plugin/plugin.json > /dev/null`
- `python3 -m json.tool .claude-plugin/marketplace.json > /dev/null`
- `python3 -m json.tool .cursor-plugin/plugin.json > /dev/null`
- `python3 -m json.tool gemini-extension.json > /dev/null`
- `python3 -m json.tool package.json > /dev/null`
- `git diff --check`
- `git diff --cached --check`