### PR TITLE
[codex] Bump plugin manifests to 1.0.4

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
       "name": "intent-fluid",
       "description": "A collection of AI Skills for intent-driven development and cognitive workflows.",
       "source": "./",
-      "version": "1.0.3"
+      "version": "1.0.4"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "intent-fluid",
   "description": "Transforming human intent into autonomous execution with AI Skills.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": { 
     "name": "carbonshow"
   },

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "intent-fluid",
   "description": "Transforming human intent into autonomous execution with AI Skills.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "carbonshow",
   "homepage": "https://github.com/carbonshow/intent-fluid",
   "repository": "https://github.com/carbonshow/intent-fluid",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2026-06-01
+
+### Changed
+- Improved `surge` user-facing output with briefing artifacts, reader summaries, and less process-heavy phase reporting.
+- Updated plugin and extension manifests to version 1.0.4.
+
 ## [1.0.3] - 2026-04-30
 
 ### Changed

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "intent-fluid",
   "description": "Transforming human intent into autonomous execution with AI Skills.",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "contextFileName": "GEMINI.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "intent-fluid",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "AI Skills for intent-driven development",
   "author": "carbonshow",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Bump Claude plugin, Claude marketplace, Cursor plugin, Gemini extension, and repo package versions to `1.0.4`.
- Add a `CHANGELOG.md` entry for the surge user-facing output changes merged in #33.

## Validation

- `python3 -m json.tool .claude-plugin/plugin.json > /dev/null`
- `python3 -m json.tool .claude-plugin/marketplace.json > /dev/null`
- `python3 -m json.tool .cursor-plugin/plugin.json > /dev/null`
- `python3 -m json.tool gemini-extension.json > /dev/null`
- `python3 -m json.tool package.json > /dev/null`
- `git diff --check`
- searched target manifests for stale `1.0.3` version strings